### PR TITLE
Expand tools API: 18 new endpoints, interactive UI, tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ sha1 = "0.10"
 sha2 = "0.10"
 md5 = "0.7"
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.8"
 hex = "0.4"
+qrcode = { version = "0.14", default-features = false, features = ["svg"] }
 
 [dependencies.rocket]
 version = "0.5.0-rc.1"
@@ -24,5 +26,3 @@ features = ["json"]
 [dependencies.rocket_dyn_templates]
 version = "0.1.0"
 features = ["handlebars", "tera"]
-
-

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -8,3 +8,12 @@ port = 8000
 # Change to 0.0.0.0 only if you need external access and have proper security measures
 address = "127.0.0.1"
 port = 8000
+
+# SECURITY: cap request body sizes so no endpoint can be used to exhaust memory.
+# (GET query inputs are additionally capped per-endpoint and by nginx URI limits.)
+[default.limits]
+forms = "32 kB"
+data-form = "256 kB"
+string = "256 kB"
+bytes = "256 kB"
+json = "256 kB"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -25,3 +25,18 @@ pub static QUOTES: &[&str] = &[
     "The future belongs to those who believe in the beauty of their dreams. - Eleanor Roosevelt",
     "It is during our darkest moments that we must focus to see the light. - Aristotle",
 ];
+
+pub static EIGHT_BALL: &[&str] = &[
+    "It is certain.",
+    "Without a doubt.",
+    "Yes, definitely.",
+    "Most likely.",
+    "Signs point to yes.",
+    "Reply hazy, try again.",
+    "Ask again later.",
+    "Cannot predict now.",
+    "Don't count on it.",
+    "My reply is no.",
+    "Very doubtful.",
+    "Outlook not so good.",
+];

--- a/src/endpoints/convert.rs
+++ b/src/endpoints/convert.rs
@@ -3,10 +3,21 @@ use rocket::serde::json::{serde_json, Json, Value};
 /// Convert an integer between bases 2..=36.
 /// `/base/convert?value=255&from=10&to=16` -> "ff"
 #[get("/base/convert?<value>&<from>&<to>")]
-pub fn base_convert(value: String, from: u32, to: u32) -> Json<Value> {
+pub fn base_convert(value: String, from: Option<String>, to: Option<String>) -> Json<Value> {
     if value.len() > 256 {
         return Json(serde_json::json!({"error": "input too large"}));
     }
+    let (from, to) = match (
+        from.as_deref().map(str::trim).map(str::parse::<u32>),
+        to.as_deref().map(str::trim).map(str::parse::<u32>),
+    ) {
+        (Some(Ok(f)), Some(Ok(t))) => (f, t),
+        _ => {
+            return Json(serde_json::json!({
+                "error": "provide from and to as integer bases, e.g. ?value=255&from=10&to=16"
+            }))
+        }
+    };
     if !(2..=36).contains(&from) || !(2..=36).contains(&to) {
         return Json(serde_json::json!({"error": "base must be between 2 and 36"}));
     }
@@ -63,12 +74,24 @@ pub fn hex_to_rgb(hex: String) -> Json<Value> {
 
 /// `/color/rgb-to-hex?r=255&g=136&b=0`
 #[get("/color/rgb-to-hex?<r>&<g>&<b>")]
-pub fn rgb_to_hex(r: u16, g: u16, b: u16) -> Json<Value> {
-    if r > 255 || g > 255 || b > 255 {
+pub fn rgb_to_hex(r: Option<String>, g: Option<String>, b: Option<String>) -> Json<Value> {
+    let parse = |o: Option<String>| -> Option<i64> {
+        o.as_deref().and_then(|s| s.trim().parse::<i64>().ok())
+    };
+    let (r, g, b) = match (parse(r), parse(g), parse(b)) {
+        (Some(r), Some(g), Some(b)) => (r, g, b),
+        _ => {
+            return Json(serde_json::json!({
+                "error": "provide r, g, b as integers, e.g. ?r=255&g=136&b=0"
+            }))
+        }
+    };
+    // Range-check explicitly so the message always fires (not swallowed by integer parsing).
+    if !(0..=255).contains(&r) || !(0..=255).contains(&g) || !(0..=255).contains(&b) {
         return Json(serde_json::json!({"error": "each channel must be 0-255"}));
     }
     Json(serde_json::json!({
-        "hex": format!("#{:02x}{:02x}{:02x}", r, g, b),
+        "hex": format!("#{:02x}{:02x}{:02x}", r as u8, g as u8, b as u8),
         "r": r, "g": g, "b": b,
     }))
 }

--- a/src/endpoints/convert.rs
+++ b/src/endpoints/convert.rs
@@ -1,0 +1,74 @@
+use rocket::serde::json::{serde_json, Json, Value};
+
+/// Convert an integer between bases 2..=36.
+/// `/base/convert?value=255&from=10&to=16` -> "ff"
+#[get("/base/convert?<value>&<from>&<to>")]
+pub fn base_convert(value: String, from: u32, to: u32) -> Json<Value> {
+    if value.len() > 256 {
+        return Json(serde_json::json!({"error": "input too large"}));
+    }
+    if !(2..=36).contains(&from) || !(2..=36).contains(&to) {
+        return Json(serde_json::json!({"error": "base must be between 2 and 36"}));
+    }
+    match i128::from_str_radix(value.trim(), from) {
+        Ok(n) => Json(serde_json::json!({
+            "input": value,
+            "from_base": from,
+            "to_base": to,
+            "decimal": n.to_string(),
+            "result": to_radix(n, to),
+        })),
+        Err(_) => Json(serde_json::json!({
+            "error": format!("'{}' is not a valid base-{} number", value, from)
+        })),
+    }
+}
+
+fn to_radix(n: i128, radix: u32) -> String {
+    if n == 0 {
+        return "0".to_string();
+    }
+    let neg = n < 0;
+    let mut x = n.unsigned_abs();
+    let digits = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    let r = radix as u128;
+    let mut out = Vec::new();
+    while x > 0 {
+        out.push(digits[(x % r) as usize]);
+        x /= r;
+    }
+    if neg {
+        out.push(b'-');
+    }
+    out.reverse();
+    String::from_utf8(out).unwrap()
+}
+
+/// `/color/hex-to-rgb?hex=ff8800`
+#[get("/color/hex-to-rgb?<hex>")]
+pub fn hex_to_rgb(hex: String) -> Json<Value> {
+    let h = hex.trim().trim_start_matches('#');
+    if h.len() != 6 || !h.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Json(serde_json::json!({"error": "expected a 6-digit hex color like ff8800"}));
+    }
+    let r = u8::from_str_radix(&h[0..2], 16).unwrap();
+    let g = u8::from_str_radix(&h[2..4], 16).unwrap();
+    let b = u8::from_str_radix(&h[4..6], 16).unwrap();
+    Json(serde_json::json!({
+        "hex": format!("#{}", h.to_lowercase()),
+        "r": r, "g": g, "b": b,
+        "rgb": format!("rgb({}, {}, {})", r, g, b),
+    }))
+}
+
+/// `/color/rgb-to-hex?r=255&g=136&b=0`
+#[get("/color/rgb-to-hex?<r>&<g>&<b>")]
+pub fn rgb_to_hex(r: u16, g: u16, b: u16) -> Json<Value> {
+    if r > 255 || g > 255 || b > 255 {
+        return Json(serde_json::json!({"error": "each channel must be 0-255"}));
+    }
+    Json(serde_json::json!({
+        "hex": format!("#{:02x}{:02x}{:02x}", r, g, b),
+        "r": r, "g": g, "b": b,
+    }))
+}

--- a/src/endpoints/encoding.rs
+++ b/src/endpoints/encoding.rs
@@ -49,7 +49,7 @@ pub fn url_decode(encoded: String) -> String {
     // SECURITY FIX: Safe URL decoding with proper UTF-8 validation
     let mut bytes = Vec::new();
     let mut chars = encoded.chars().peekable();
-    
+
     while let Some(c) = chars.next() {
         if c == '%' {
             if let (Some(h1), Some(h2)) = (chars.next(), chars.next()) {
@@ -71,7 +71,102 @@ pub fn url_decode(encoded: String) -> String {
             bytes.extend_from_slice(c.to_string().as_bytes());
         }
     }
-    
+
     // SECURITY FIX: Use from_utf8_lossy for safe UTF-8 conversion
     String::from_utf8_lossy(&bytes).to_string()
+}
+
+// ---- Additional encoders (query-param based) ----
+
+const MAX_ENC: usize = 100_000;
+
+/// `/hex/encode?text=hi` -> "6869"
+#[get("/hex/encode?<text>")]
+pub fn hex_encode(text: String) -> String {
+    if text.len() > MAX_ENC {
+        return "Error: input too large (max 100KB)".to_string();
+    }
+    hex::encode(text.as_bytes())
+}
+
+/// `/hex/decode?input=6869` -> "hi"
+#[get("/hex/decode?<input>")]
+pub fn hex_decode(input: String) -> String {
+    if input.len() > 2 * MAX_ENC {
+        return "Error: input too large".to_string();
+    }
+    match hex::decode(input.trim()) {
+        Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+        Err(_) => "Error: invalid hex".to_string(),
+    }
+}
+
+/// `/rot13?text=Hello` -> "Uryyb" (self-inverse)
+#[get("/rot13?<text>")]
+pub fn rot13(text: String) -> String {
+    if text.len() > MAX_ENC {
+        return "Error: input too large".to_string();
+    }
+    text.chars()
+        .map(|c| match c {
+            'a'..='z' => (((c as u8 - b'a' + 13) % 26) + b'a') as char,
+            'A'..='Z' => (((c as u8 - b'A' + 13) % 26) + b'A') as char,
+            _ => c,
+        })
+        .collect()
+}
+
+/// `/html/encode?text=<b>` -> "&lt;b&gt;"
+#[get("/html/encode?<text>")]
+pub fn html_encode(text: String) -> String {
+    if text.len() > MAX_ENC {
+        return "Error: input too large".to_string();
+    }
+    text.chars()
+        .map(|c| match c {
+            '&' => "&amp;".to_string(),
+            '<' => "&lt;".to_string(),
+            '>' => "&gt;".to_string(),
+            '"' => "&quot;".to_string(),
+            '\'' => "&#x27;".to_string(),
+            _ => c.to_string(),
+        })
+        .collect()
+}
+
+/// `/html/decode?text=&lt;b&gt;` -> "<b>"
+#[get("/html/decode?<text>")]
+pub fn html_decode(text: String) -> String {
+    if text.len() > MAX_ENC {
+        return "Error: input too large".to_string();
+    }
+    // Decode named entities first, then &amp; LAST to avoid double-unescaping.
+    let s = text
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#x27;", "'")
+        .replace("&#39;", "'");
+    s.replace("&amp;", "&")
+}
+
+/// `/base64url/encode?text=hello` -> URL-safe base64 without padding
+#[get("/base64url/encode?<text>")]
+pub fn base64url_encode(text: String) -> String {
+    if text.len() > 1_000_000 {
+        return "Error: input too large (max 1MB)".to_string();
+    }
+    general_purpose::URL_SAFE_NO_PAD.encode(text.as_bytes())
+}
+
+/// `/base64url/decode?input=...`
+#[get("/base64url/decode?<input>")]
+pub fn base64url_decode(input: String) -> String {
+    if input.len() > 1_500_000 {
+        return "Error: input too large".to_string();
+    }
+    match general_purpose::URL_SAFE_NO_PAD.decode(input.trim()) {
+        Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+        Err(_) => "Error: invalid base64url".to_string(),
+    }
 }

--- a/src/endpoints/fun.rs
+++ b/src/endpoints/fun.rs
@@ -1,5 +1,7 @@
 use rand::Rng;
-use crate::constants::{CAT_FACTS, QUOTES};
+use rocket::serde::json::{serde_json, Json, Value};
+
+use crate::constants::{CAT_FACTS, EIGHT_BALL, QUOTES};
 
 // Fun endpoints
 #[get("/cat-fact")]
@@ -14,4 +16,81 @@ pub fn quote() -> String {
     let mut rng = rand::thread_rng();
     let index = rng.gen_range(0..QUOTES.len());
     QUOTES[index].to_string()
+}
+
+/// Roll dice in `NdM` notation, e.g. `/roll/2d6`. Capped at 100 dice / 1000 sides.
+#[get("/roll/<dice>")]
+pub fn roll(dice: String) -> Json<Value> {
+    let lower = dice.to_lowercase();
+    let parts: Vec<&str> = lower.split('d').collect();
+    if parts.len() != 2 {
+        return Json(serde_json::json!({"error": "format: NdM, e.g. 2d6"}));
+    }
+
+    let count: u32 = if parts[0].is_empty() {
+        1
+    } else {
+        match parts[0].parse() {
+            Ok(v) => v,
+            Err(_) => return Json(serde_json::json!({"error": "invalid dice count"})),
+        }
+    };
+    let sides: u32 = match parts[1].parse() {
+        Ok(v) => v,
+        Err(_) => return Json(serde_json::json!({"error": "invalid number of sides"})),
+    };
+
+    if !(1..=100).contains(&count) {
+        return Json(serde_json::json!({"error": "dice count must be 1-100"}));
+    }
+    if !(2..=1000).contains(&sides) {
+        return Json(serde_json::json!({"error": "sides must be 2-1000"}));
+    }
+
+    let mut rng = rand::thread_rng();
+    let rolls: Vec<u32> = (0..count).map(|_| rng.gen_range(1..=sides)).collect();
+    let total: u64 = rolls.iter().map(|&r| r as u64).sum();
+
+    Json(serde_json::json!({
+        "dice": dice,
+        "rolls": rolls,
+        "total": total,
+    }))
+}
+
+#[get("/coinflip")]
+pub fn coinflip() -> Json<Value> {
+    let mut rng = rand::thread_rng();
+    Json(serde_json::json!({
+        "result": if rng.gen::<bool>() { "heads" } else { "tails" }
+    }))
+}
+
+#[get("/8ball")]
+pub fn eight_ball() -> Json<Value> {
+    let mut rng = rand::thread_rng();
+    let index = rng.gen_range(0..EIGHT_BALL.len());
+    Json(serde_json::json!({"answer": EIGHT_BALL[index]}))
+}
+
+/// Pick a random option. `/pick?options=red,green,blue`
+#[get("/pick?<options>")]
+pub fn pick(options: String) -> Json<Value> {
+    if options.len() > 10_000 {
+        return Json(serde_json::json!({"error": "input too large"}));
+    }
+    let opts: Vec<&str> = options
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if opts.is_empty() {
+        return Json(serde_json::json!({"error": "provide comma-separated options, e.g. a,b,c"}));
+    }
+    let mut rng = rand::thread_rng();
+    let index = rng.gen_range(0..opts.len());
+    Json(serde_json::json!({
+        "options": opts,
+        "chosen": opts[index],
+    }))
 }

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -1,7 +1,10 @@
 pub mod basic;
+pub mod convert;
 pub mod crypto;
 pub mod encoding;
 pub mod fun;
 pub mod generators;
+pub mod qr;
+pub mod text;
 pub mod time;
 pub mod utils;

--- a/src/endpoints/qr.rs
+++ b/src/endpoints/qr.rs
@@ -1,0 +1,34 @@
+use qrcode::render::svg;
+use qrcode::QrCode;
+use rocket::http::ContentType;
+
+// SECURITY: hard cap on input so QR generation can't be used to burn CPU/memory.
+const MAX_QR_TEXT: usize = 1_000;
+
+/// `/qr?text=hello` -> an SVG QR code (Content-Type: image/svg+xml).
+#[get("/qr?<text>")]
+pub fn qr(text: String) -> (ContentType, String) {
+    if text.is_empty() {
+        return (ContentType::Plain, "Error: provide ?text=...".to_string());
+    }
+    if text.len() > MAX_QR_TEXT {
+        return (
+            ContentType::Plain,
+            format!("Error: text too large (max {} chars)", MAX_QR_TEXT),
+        );
+    }
+    match QrCode::new(text.as_bytes()) {
+        Ok(code) => {
+            let image = code
+                .render::<svg::Color>()
+                .min_dimensions(200, 200)
+                .max_dimensions(600, 600)
+                .build();
+            (ContentType::SVG, image)
+        }
+        Err(_) => (
+            ContentType::Plain,
+            "Error: input exceeds QR code capacity".to_string(),
+        ),
+    }
+}

--- a/src/endpoints/text.rs
+++ b/src/endpoints/text.rs
@@ -1,0 +1,103 @@
+use rocket::serde::json::{serde_json, Json, Value};
+
+// SECURITY: cap text inputs so no single request can exhaust CPU/memory.
+const MAX_TEXT: usize = 10_000;
+
+fn too_large_str() -> String {
+    "Error: input too large (max 10000 chars)".to_string()
+}
+
+/// `/text/slugify?text=Hello World!` -> `hello-world`
+#[get("/text/slugify?<text>")]
+pub fn slugify(text: String) -> String {
+    if text.len() > MAX_TEXT {
+        return too_large_str();
+    }
+    let mut slug = String::new();
+    let mut prev_dash = false;
+    for c in text.to_lowercase().chars() {
+        if c.is_alphanumeric() {
+            slug.push(c);
+            prev_dash = false;
+        } else if !prev_dash && !slug.is_empty() {
+            slug.push('-');
+            prev_dash = true;
+        }
+    }
+    while slug.ends_with('-') {
+        slug.pop();
+    }
+    slug
+}
+
+/// `/text/reverse?text=abc` -> `cba`
+#[get("/text/reverse?<text>")]
+pub fn reverse(text: String) -> String {
+    if text.len() > MAX_TEXT {
+        return too_large_str();
+    }
+    text.chars().rev().collect()
+}
+
+/// `/text/count?text=...` -> counts of chars/bytes/words/lines
+#[get("/text/count?<text>")]
+pub fn count(text: String) -> Json<Value> {
+    if text.len() > MAX_TEXT {
+        return Json(serde_json::json!({"error": "input too large (max 10000 chars)"}));
+    }
+    Json(serde_json::json!({
+        "characters": text.chars().count(),
+        "bytes": text.len(),
+        "words": text.split_whitespace().count(),
+        "lines": if text.is_empty() { 0 } else { text.lines().count() },
+    }))
+}
+
+/// `/text/case/<mode>?text=...` where mode = upper|lower|title|snake|kebab|camel
+#[get("/text/case/<mode>?<text>")]
+pub fn case(mode: String, text: String) -> String {
+    if text.len() > MAX_TEXT {
+        return too_large_str();
+    }
+    match mode.to_lowercase().as_str() {
+        "upper" => text.to_uppercase(),
+        "lower" => text.to_lowercase(),
+        "title" => text
+            .split_whitespace()
+            .map(|w| {
+                let mut c = w.chars();
+                match c.next() {
+                    Some(f) => f.to_uppercase().collect::<String>() + &c.as_str().to_lowercase(),
+                    None => String::new(),
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" "),
+        "snake" => text
+            .to_lowercase()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join("_"),
+        "kebab" => text
+            .to_lowercase()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join("-"),
+        "camel" => {
+            let mut out = String::new();
+            for (i, w) in text.split_whitespace().enumerate() {
+                let mut ch = w.chars();
+                if let Some(f) = ch.next() {
+                    if i == 0 {
+                        out.push_str(&f.to_lowercase().collect::<String>());
+                    } else {
+                        out.push_str(&f.to_uppercase().collect::<String>());
+                    }
+                    out.push_str(&ch.as_str().to_lowercase());
+                }
+            }
+            out
+        }
+        _ => "Error: unsupported case (upper, lower, title, snake, kebab, camel)".to_string(),
+    }
+}

--- a/src/endpoints/time.rs
+++ b/src/endpoints/time.rs
@@ -19,7 +19,11 @@ pub fn timestamp() -> Json<TimestampResponse> {
 /// Convert a unix timestamp to a human-readable date.
 /// `/timestamp/1781022640` -> formatted UTC + ISO8601. Auto-detects ms vs s.
 #[get("/timestamp/<unix>")]
-pub fn timestamp_to_date(unix: i64) -> Json<Value> {
+pub fn timestamp_to_date(unix: String) -> Json<Value> {
+    let unix: i64 = match unix.trim().parse() {
+        Ok(n) => n,
+        Err(_) => return Json(serde_json::json!({"error": "timestamp must be an integer"})),
+    };
     // Heuristic: values beyond ~year 5138 in seconds are almost certainly milliseconds.
     let (secs, unit) = if unix.abs() > 100_000_000_000 {
         (unix / 1000, "milliseconds")
@@ -71,7 +75,11 @@ pub fn time_tz(tz: PathBuf) -> Json<TimeResponse> {
 
 /// Humanize a duration in seconds. `/duration?seconds=90061` -> "1d 1h 1m 1s"
 #[get("/duration?<seconds>")]
-pub fn duration(seconds: i64) -> Json<Value> {
+pub fn duration(seconds: Option<String>) -> Json<Value> {
+    let seconds: i64 = match seconds.as_deref().map(str::trim).map(str::parse) {
+        Some(Ok(n)) => n,
+        _ => return Json(serde_json::json!({"error": "provide ?seconds=<integer>"})),
+    };
     let s = seconds.abs();
     let days = s / 86_400;
     let hours = (s % 86_400) / 3_600;

--- a/src/endpoints/time.rs
+++ b/src/endpoints/time.rs
@@ -1,6 +1,10 @@
-use chrono::Utc;
-use rocket::serde::json::Json;
-use crate::types::{TimestampResponse, TimeResponse};
+use std::path::PathBuf;
+
+use chrono::{TimeZone, Utc};
+use chrono_tz::Tz;
+use rocket::serde::json::{serde_json, Json, Value};
+
+use crate::types::{TimeResponse, TimestampResponse};
 
 // Time endpoints
 #[get("/timestamp")]
@@ -12,6 +16,27 @@ pub fn timestamp() -> Json<TimestampResponse> {
     })
 }
 
+/// Convert a unix timestamp to a human-readable date.
+/// `/timestamp/1781022640` -> formatted UTC + ISO8601. Auto-detects ms vs s.
+#[get("/timestamp/<unix>")]
+pub fn timestamp_to_date(unix: i64) -> Json<Value> {
+    // Heuristic: values beyond ~year 5138 in seconds are almost certainly milliseconds.
+    let (secs, unit) = if unix.abs() > 100_000_000_000 {
+        (unix / 1000, "milliseconds")
+    } else {
+        (unix, "seconds")
+    };
+    match Utc.timestamp_opt(secs, 0).single() {
+        Some(dt) => Json(serde_json::json!({
+            "unix": unix,
+            "interpreted_as": unit,
+            "utc": dt.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+            "iso8601": dt.to_rfc3339(),
+        })),
+        None => Json(serde_json::json!({"error": "invalid timestamp"})),
+    }
+}
+
 #[get("/time/utc")]
 pub fn time_utc() -> Json<TimeResponse> {
     let now = Utc::now();
@@ -21,14 +46,57 @@ pub fn time_utc() -> Json<TimeResponse> {
     })
 }
 
-#[get("/time/<tz>")]
-pub fn time_tz(tz: String) -> Json<TimeResponse> {
-    let now = Utc::now();
-    
-    // For simplicity, we'll just return UTC time with the requested timezone name
-    // In a production app, you'd want to use a proper timezone library
-    Json(TimeResponse {
-        datetime: now.format("%Y-%m-%d %H:%M:%S").to_string(),
-        timezone: tz,
-    })
+/// Current time in an IANA timezone, e.g. `/time/America/New_York` or `/time/Asia/Dubai`.
+/// Uses `<tz..>` so multi-segment zone names like `America/New_York` work.
+#[get("/time/<tz..>")]
+pub fn time_tz(tz: PathBuf) -> Json<TimeResponse> {
+    let name = tz.to_string_lossy().to_string();
+    match name.parse::<Tz>() {
+        Ok(zone) => {
+            let now = Utc::now().with_timezone(&zone);
+            Json(TimeResponse {
+                datetime: now.format("%Y-%m-%d %H:%M:%S").to_string(),
+                timezone: zone.name().to_string(),
+            })
+        }
+        Err(_) => Json(TimeResponse {
+            datetime: String::new(),
+            timezone: format!(
+                "unknown timezone '{}' (use IANA names like America/New_York or Asia/Dubai)",
+                name
+            ),
+        }),
+    }
+}
+
+/// Humanize a duration in seconds. `/duration?seconds=90061` -> "1d 1h 1m 1s"
+#[get("/duration?<seconds>")]
+pub fn duration(seconds: i64) -> Json<Value> {
+    let s = seconds.abs();
+    let days = s / 86_400;
+    let hours = (s % 86_400) / 3_600;
+    let mins = (s % 3_600) / 60;
+    let secs = s % 60;
+
+    let mut parts: Vec<String> = Vec::new();
+    if days > 0 {
+        parts.push(format!("{}d", days));
+    }
+    if hours > 0 {
+        parts.push(format!("{}h", hours));
+    }
+    if mins > 0 {
+        parts.push(format!("{}m", mins));
+    }
+    if secs > 0 || parts.is_empty() {
+        parts.push(format!("{}s", secs));
+    }
+
+    Json(serde_json::json!({
+        "seconds": seconds,
+        "human": parts.join(" "),
+        "days": days,
+        "hours": hours,
+        "minutes": mins,
+    }))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,4 +293,41 @@ mod route_tests {
         let (_, b) = get_text(&format!("/text/reverse?text={}", big));
         assert!(b.starts_with("Error:"));
     }
+
+    // ---- friendly errors for missing / invalid params ----
+    #[test]
+    fn duration_missing_param_is_friendly_json() {
+        let (s, v) = get_json("/duration");
+        assert_eq!(s, Status::Ok);
+        assert!(v["error"].is_string());
+    }
+
+    #[test]
+    fn timestamp_to_date_rejects_non_integer() {
+        let (_, v) = get_json("/timestamp/notanumber");
+        assert!(v["error"].is_string());
+    }
+
+    #[test]
+    fn base_convert_missing_bases_is_friendly() {
+        let (_, v) = get_json("/base/convert?value=255");
+        assert!(v["error"].is_string());
+    }
+
+    #[test]
+    fn rgb_invalid_and_out_of_range_both_error() {
+        // non-numeric
+        let (_, v1) = get_json("/color/rgb-to-hex?r=abc&g=0&b=0");
+        assert!(v1["error"].is_string());
+        // out of range still hits the explicit 0-255 message
+        let (_, v2) = get_json("/color/rgb-to-hex?r=300&g=0&b=0");
+        assert_eq!(v2["error"], "each channel must be 0-255");
+    }
+
+    #[test]
+    fn base64url_decode_roundtrip() {
+        let enc = get_text("/base64url/encode?text=hello%20world").1;
+        let dec = get_text(&format!("/base64url/decode?input={}", enc)).1;
+        assert_eq!(dec, "hello world");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod types;
 
 use rocket_dyn_templates::Template;
 
-use endpoints::{basic, crypto, encoding, fun, generators, time, utils};
+use endpoints::{basic, convert, crypto, encoding, fun, generators, qr, text, time, utils};
 
 pub fn create_rocket() -> rocket::Rocket<rocket::Build> {
     rocket::build()
@@ -33,17 +33,264 @@ pub fn create_rocket() -> rocket::Rocket<rocket::Build> {
             encoding::base64_decode,
             encoding::url_encode,
             encoding::url_decode,
+            encoding::hex_encode,
+            encoding::hex_decode,
+            encoding::rot13,
+            encoding::html_encode,
+            encoding::html_decode,
+            encoding::base64url_encode,
+            encoding::base64url_decode,
             crypto::hash,
+            crypto::jwt_decode,
             time::timestamp,
+            time::timestamp_to_date,
             time::time_utc,
             time::time_tz,
-            crypto::jwt_decode,
+            time::duration,
+            text::slugify,
+            text::reverse,
+            text::count,
+            text::case,
+            convert::base_convert,
+            convert::hex_to_rgb,
+            convert::rgb_to_hex,
             fun::cat_fact,
-            fun::quote
+            fun::quote,
+            fun::roll,
+            fun::coinflip,
+            fun::eight_ball,
+            fun::pick,
+            qr::qr,
         ])
 }
 
 #[launch]
 fn rocket() -> _ {
     create_rocket()
+}
+
+#[cfg(test)]
+mod route_tests {
+    use super::create_rocket;
+    use rocket::http::{ContentType, Status};
+    use rocket::local::blocking::Client;
+    use rocket::serde::json::serde_json::Value;
+
+    fn client() -> Client {
+        Client::tracked(create_rocket()).expect("rocket failed to ignite")
+    }
+
+    fn get_text(path: &str) -> (Status, String) {
+        let c = client();
+        let res = c.get(path).dispatch();
+        let status = res.status();
+        (status, res.into_string().unwrap_or_default())
+    }
+
+    fn get_json(path: &str) -> (Status, Value) {
+        let c = client();
+        let res = c.get(path).dispatch();
+        let status = res.status();
+        let body = res.into_string().unwrap_or_default();
+        let value: Value = rocket::serde::json::serde_json::from_str(&body)
+            .unwrap_or_else(|_| panic!("non-JSON body for {}: {}", path, body));
+        (status, value)
+    }
+
+    // ---- sanity / existing ----
+    #[test]
+    fn ping_works() {
+        let (s, b) = get_text("/ping");
+        assert_eq!(s, Status::Ok);
+        assert_eq!(b, "pong");
+    }
+
+    #[test]
+    fn index_renders() {
+        let (s, _) = get_text("/");
+        assert_eq!(s, Status::Ok);
+    }
+
+    #[test]
+    fn uuid_has_correct_shape() {
+        let (s, b) = get_text("/uuid");
+        assert_eq!(s, Status::Ok);
+        assert_eq!(b.len(), 36);
+        assert_eq!(b.matches('-').count(), 4);
+    }
+
+    // ---- time ----
+    #[test]
+    fn timestamp_to_date_seconds() {
+        let (s, v) = get_json("/timestamp/1781022640");
+        assert_eq!(s, Status::Ok);
+        assert_eq!(v["interpreted_as"], "seconds");
+        assert_eq!(v["utc"], "2026-06-09 16:30:40 UTC");
+    }
+
+    #[test]
+    fn timestamp_to_date_detects_millis() {
+        let (_, v) = get_json("/timestamp/1781022640255");
+        assert_eq!(v["interpreted_as"], "milliseconds");
+    }
+
+    #[test]
+    fn time_tz_resolves_iana_zone() {
+        let (s, v) = get_json("/time/Asia/Dubai");
+        assert_eq!(s, Status::Ok);
+        assert_eq!(v["timezone"], "Asia/Dubai");
+        assert!(!v["datetime"].as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn time_tz_rejects_bad_zone() {
+        let (_, v) = get_json("/time/Not/AZone");
+        assert!(v["timezone"].as_str().unwrap().contains("unknown timezone"));
+    }
+
+    #[test]
+    fn duration_humanizes() {
+        let (s, v) = get_json("/duration?seconds=90061");
+        assert_eq!(s, Status::Ok);
+        assert_eq!(v["human"], "1d 1h 1m 1s");
+        assert_eq!(v["days"], 1);
+    }
+
+    // ---- text ----
+    #[test]
+    fn slugify_basic() {
+        assert_eq!(get_text("/text/slugify?text=Hello%20World%21").1, "hello-world");
+    }
+
+    #[test]
+    fn reverse_basic() {
+        assert_eq!(get_text("/text/reverse?text=stressed").1, "desserts");
+    }
+
+    #[test]
+    fn count_basic() {
+        let (_, v) = get_json("/text/count?text=the%20quick%20brown%20fox");
+        assert_eq!(v["words"], 4);
+        assert_eq!(v["characters"], 19);
+    }
+
+    #[test]
+    fn case_modes() {
+        assert_eq!(get_text("/text/case/upper?text=hi%20yo").1, "HI YO");
+        assert_eq!(get_text("/text/case/title?text=hello%20world").1, "Hello World");
+        assert_eq!(get_text("/text/case/snake?text=hello%20world").1, "hello_world");
+        assert_eq!(get_text("/text/case/kebab?text=hello%20world").1, "hello-world");
+        assert_eq!(get_text("/text/case/camel?text=hello%20world").1, "helloWorld");
+    }
+
+    // ---- encoding ----
+    #[test]
+    fn hex_roundtrip() {
+        assert_eq!(get_text("/hex/encode?text=hi").1, "6869");
+        assert_eq!(get_text("/hex/decode?input=6869").1, "hi");
+    }
+
+    #[test]
+    fn rot13_is_self_inverse() {
+        assert_eq!(get_text("/rot13?text=Hello").1, "Uryyb");
+        assert_eq!(get_text("/rot13?text=Uryyb").1, "Hello");
+    }
+
+    #[test]
+    fn html_encode_decode_roundtrip() {
+        assert_eq!(get_text("/html/encode?text=%3Cb%3Ehi%3C%2Fb%3E").1, "&lt;b&gt;hi&lt;/b&gt;");
+        assert_eq!(get_text("/html/decode?text=%26lt%3Bb%26gt%3Bhi%26lt%3B%2Fb%26gt%3B").1, "<b>hi</b>");
+    }
+
+    #[test]
+    fn base64url_encodes_without_padding() {
+        let b = get_text("/base64url/encode?text=hello%20world").1;
+        assert_eq!(b, "aGVsbG8gd29ybGQ");
+        assert!(!b.contains('='));
+    }
+
+    // ---- convert ----
+    #[test]
+    fn base_convert_dec_to_hex() {
+        let (_, v) = get_json("/base/convert?value=255&from=10&to=16");
+        assert_eq!(v["result"], "ff");
+    }
+
+    #[test]
+    fn base_convert_rejects_bad_base() {
+        let (_, v) = get_json("/base/convert?value=10&from=10&to=99");
+        assert!(v["error"].is_string());
+    }
+
+    #[test]
+    fn color_conversions_roundtrip() {
+        let (_, v) = get_json("/color/hex-to-rgb?hex=ff8800");
+        assert_eq!(v["r"], 255);
+        assert_eq!(v["g"], 136);
+        let (_, v2) = get_json("/color/rgb-to-hex?r=255&g=136&b=0");
+        assert_eq!(v2["hex"], "#ff8800");
+    }
+
+    #[test]
+    fn rgb_rejects_out_of_range() {
+        let (_, v) = get_json("/color/rgb-to-hex?r=999&g=0&b=0");
+        assert!(v["error"].is_string());
+    }
+
+    // ---- fun ----
+    #[test]
+    fn roll_within_bounds() {
+        let (s, v) = get_json("/roll/3d6");
+        assert_eq!(s, Status::Ok);
+        let rolls = v["rolls"].as_array().unwrap();
+        assert_eq!(rolls.len(), 3);
+        for r in rolls {
+            let n = r.as_u64().unwrap();
+            assert!((1..=6).contains(&n));
+        }
+    }
+
+    #[test]
+    fn roll_rejects_excessive_dice() {
+        let (_, v) = get_json("/roll/9999d6");
+        assert!(v["error"].is_string());
+    }
+
+    #[test]
+    fn coinflip_is_heads_or_tails() {
+        let (_, v) = get_json("/coinflip");
+        let r = v["result"].as_str().unwrap();
+        assert!(r == "heads" || r == "tails");
+    }
+
+    #[test]
+    fn pick_chooses_from_options() {
+        let (_, v) = get_json("/pick?options=red,green,blue");
+        let chosen = v["chosen"].as_str().unwrap();
+        assert!(["red", "green", "blue"].contains(&chosen));
+    }
+
+    // ---- qr / limits ----
+    #[test]
+    fn qr_returns_svg() {
+        let c = client();
+        let res = c.get("/qr?text=hello").dispatch();
+        assert_eq!(res.status(), Status::Ok);
+        assert_eq!(res.content_type(), Some(ContentType::SVG));
+        assert!(res.into_string().unwrap().contains("<svg"));
+    }
+
+    #[test]
+    fn qr_rejects_oversized_input() {
+        let big = "a".repeat(2000);
+        let (_, b) = get_text(&format!("/qr?text={}", big));
+        assert!(b.starts_with("Error:"));
+    }
+
+    #[test]
+    fn text_endpoints_enforce_size_cap() {
+        let big = "a".repeat(20_000);
+        let (_, b) = get_text(&format!("/text/reverse?text={}", big));
+        assert!(b.starts_with("Error:"));
+    }
 }

--- a/templates/index.html.hbs
+++ b/templates/index.html.hbs
@@ -4,196 +4,271 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tools - StackFrost</title>
-
+    <title>Tools · StackFrost</title>
+    <meta name="description" content="A small collection of developer utility endpoints — each usable as a web form or a JSON/text API.">
     <style>
+        :root {
+            --bg: #0d1117;
+            --panel: #161b22;
+            --border: #21262d;
+            --text: #e6edf3;
+            --muted: #8b949e;
+            --accent: #58a6ff;
+            --accent-soft: rgba(88, 166, 255, 0.12);
+            --ok: #3fb950;
+            --radius: 12px;
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
         body {
-            margin: 0 auto;
-            font-family: Arial, Helvetica, sans-serif;
-            color: #444444;
-            line-height: 1;
-            max-width: 960px;
-            padding: 30px;
-        }
-
-        h1,
-        h2,
-        h3,
-        h4 {
-            color: #111111;
-            font-weight: 400;
-        }
-
-        h1,
-        h2,
-        h3,
-        h4,
-        h5,
-        p {
-            margin-bottom: 24px;
-            padding: 0;
-        }
-
-        h1 {
-            font-size: 48px;
-        }
-
-        h2 {
-            font-size: 36px;
-            margin: 24px 0 6px;
-        }
-
-        h3 {
-            font-size: 24px;
-        }
-
-        h4 {
-            font-size: 21px;
-        }
-
-        h5 {
-            font-size: 18px;
-        }
-
-        a {
-            color: #0099ff;
-            margin: 0;
-            padding: 0;
-            vertical-align: baseline;
-        }
-
-        ul,
-        ol {
-            padding: 0;
-            margin: 0;
-        }
-
-        li {
-            line-height: 24px;
-        }
-
-        li ul,
-        li ul {
-            margin-left: 24px;
-        }
-
-        p,
-        ul,
-        ol {
-            font-size: 16px;
-            line-height: 24px;
-            max-width: 540px;
-        }
-
-        pre {
-            padding: 0px 24px;
-            max-width: 800px;
-            white-space: pre-wrap;
-        }
-
-        code {
-            font-family: Consolas, Monaco, Andale Mono, monospace;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background: var(--bg);
+            color: var(--text);
             line-height: 1.5;
-            font-size: 13px;
+            -webkit-font-smoothing: antialiased;
+            padding: 40px 20px 80px;
         }
 
-        aside {
-            display: block;
-            float: right;
-            width: 390px;
+        .wrap { max-width: 1100px; margin: 0 auto; }
+
+        header.page { margin-bottom: 28px; }
+        header.page h1 { font-size: 2rem; letter-spacing: -0.02em; }
+        header.page p { color: var(--muted); margin-top: 8px; max-width: 70ch; }
+        header.page code { color: var(--accent); }
+
+        .controls { display: flex; gap: 12px; flex-wrap: wrap; margin: 22px 0 8px; }
+        #search {
+            flex: 1; min-width: 220px;
+            background: var(--panel); border: 1px solid var(--border);
+            color: var(--text); border-radius: var(--radius);
+            padding: 10px 14px; font-size: 0.95rem;
+        }
+        #search:focus { outline: none; border-color: var(--accent); }
+
+        .cat { margin-top: 34px; }
+        .cat h2 {
+            font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.12em;
+            color: var(--muted); font-weight: 600; margin-bottom: 14px;
+            border-bottom: 1px solid var(--border); padding-bottom: 8px;
         }
 
-        blockquote {
-            margin: 1em 2em;
-            max-width: 476px;
-        }
+        .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 14px; }
 
-        blockquote p {
-            color: #666;
-            max-width: 460px;
+        .card {
+            background: var(--panel); border: 1px solid var(--border);
+            border-radius: var(--radius); padding: 16px;
+            display: flex; flex-direction: column; gap: 10px;
         }
+        .card h3 { font-size: 1rem; font-weight: 600; }
+        .card .desc { color: var(--muted); font-size: 0.85rem; }
+        .card .path { font-family: Consolas, Monaco, monospace; font-size: 0.78rem; color: var(--accent); word-break: break-all; }
 
-        hr {
-            width: 540px;
-            text-align: left;
-            margin: 0 auto 0 0;
-            color: #999;
+        .inputs { display: flex; flex-direction: column; gap: 8px; }
+        .inputs input {
+            background: var(--bg); border: 1px solid var(--border); color: var(--text);
+            border-radius: 8px; padding: 8px 10px; font-size: 0.88rem; width: 100%;
         }
+        .inputs input:focus { outline: none; border-color: var(--accent); }
 
-        table {
-            border-collapse: collapse;
-            margin: 1em 1em;
-            border: 1px solid #CCC;
+        .row { display: flex; gap: 8px; align-items: center; }
+        button.run {
+            background: var(--accent-soft); border: 1px solid var(--accent);
+            color: var(--accent); border-radius: 8px; padding: 8px 16px;
+            font-weight: 600; font-size: 0.85rem; cursor: pointer; transition: background .15s;
         }
+        button.run:hover { background: var(--accent); color: #fff; }
+        a.apilink { color: var(--muted); font-size: 0.78rem; text-decoration: none; margin-left: auto; }
+        a.apilink:hover { color: var(--accent); text-decoration: underline; }
 
-        table thead {
-            background-color: #EEE;
+        .result {
+            display: none; background: var(--bg); border: 1px solid var(--border);
+            border-radius: 8px; padding: 10px; font-family: Consolas, Monaco, monospace;
+            font-size: 0.8rem; white-space: pre-wrap; word-break: break-word; max-height: 280px; overflow: auto;
         }
+        .result.show { display: block; }
+        .result.err { border-color: #f85149; color: #ff7b72; }
+        .result svg { max-width: 220px; height: auto; background: #fff; border-radius: 6px; }
 
-        table thead td {
-            color: #666;
-        }
-
-        table td {
-            padding: 0.5em 1em;
-            border: 1px solid #CCC;
-        }
+        footer { margin-top: 60px; color: var(--muted); font-size: 0.8rem; text-align: center; }
+        footer a { color: var(--accent); text-decoration: none; }
     </style>
 </head>
 
 <body>
-    <h2>Tools</h2>
-    <ul>
-        <li>
-            <a href="/whoami"><strong>whoami</strong></a>
-            echo back IP, Headers &amp; cookies
-        </li>
-        <li>
-            <a href="/ip"><strong>ip</strong></a>
-            get your public IP address
-        </li>
-        <li>
-            <a href="/headers"><strong>headers</strong></a>
-            view all request headers
-        </li>
-        <li>
-            <a href="/uuid"><strong>uuid</strong></a>
-            generate random UUID
-        </li>
-        <li>
-            <a href="/base64/hello"><strong>base64/{text}</strong></a>
-            encode text to base64
-        </li>
-        <li>
-            <a href="/hash/sha256/hello"><strong>hash/{algo}/{text}</strong></a>
-            hash text (md5, sha1, sha256)
-        </li>
-        <li>
-            <a href="/password/16"><strong>password/{length}</strong></a>
-            generate secure password
-        </li>
-        <li>
-            <a href="/lorem/10"><strong>lorem/{words}</strong></a>
-            generate lorem ipsum text
-        </li>
-        <li>
-            <a href="/timestamp"><strong>timestamp</strong></a>
-            get current unix timestamp
-        </li>
-        <li>
-            <a href="/color"><strong>color</strong></a>
-            random hex color
-        </li>
-        <li>
-            <a href="/ping"><strong>ping</strong></a>
-            simple ping test
-        </li>
-        <li>
-            <a href="/cat-fact"><strong>cat-fact</strong></a>
-            random cat fact
-        </li>
-    </ul>
+    <div class="wrap">
+        <header class="page">
+            <h1>🛠️ Tools</h1>
+            <p>A small collection of developer utilities. Every tool works as a form below <em>and</em> as a plain
+                <code>GET</code> API — click <strong>API ↗</strong> on any card to hit the raw endpoint.</p>
+        </header>
 
+        <div class="controls">
+            <input id="search" type="search" placeholder="Filter tools… (e.g. base64, time, color)" autocomplete="off">
+        </div>
+
+        <div id="app"></div>
+
+        <footer>
+            <span id="count"></span> · built with Rust + Rocket ·
+            <a href="https://github.com/shahzaib-sheikh/tools-api">source</a>
+        </footer>
+    </div>
+
+    <script>
+        // Tool registry. Each tool: how to build its URL, its inputs, and how to render the response.
+        // kind: "json" | "text" | "svg"
+        const TOOLS = [
+            { cat: "Request", id: "whoami", name: "whoami", desc: "Your IP, headers & cookies", kind: "json", path: () => "/whoami" },
+            { cat: "Request", id: "ip", name: "ip", desc: "Your public IP address", kind: "text", path: () => "/ip" },
+            { cat: "Request", id: "headers", name: "headers", desc: "All request headers", kind: "json", path: () => "/headers" },
+            { cat: "Request", id: "ua", name: "user-agent", desc: "Your user agent string", kind: "text", path: () => "/user-agent" },
+            { cat: "Request", id: "ping", name: "ping", desc: "Health check → pong", kind: "text", path: () => "/ping" },
+
+            { cat: "Generators", id: "uuid", name: "uuid", desc: "Random UUID v4", kind: "text", path: () => "/uuid" },
+            { cat: "Generators", id: "pw", name: "password", desc: "Secure random password", kind: "text", inputs: [{ k: "length", ph: "length (1-128)", def: "20" }], path: v => `/password/${encodeURIComponent(v.length || 16)}` },
+            { cat: "Generators", id: "lorem", name: "lorem", desc: "Lorem ipsum words", kind: "text", inputs: [{ k: "words", ph: "word count (1-1000)", def: "20" }], path: v => `/lorem/${encodeURIComponent(v.words || 10)}` },
+            { cat: "Generators", id: "num", name: "number", desc: "Random number in range", kind: "text", inputs: [{ k: "min", ph: "min", def: "1" }, { k: "max", ph: "max", def: "100" }], path: v => `/number/${encodeURIComponent(v.min || 0)}/${encodeURIComponent(v.max || 100)}` },
+            { cat: "Generators", id: "color", name: "color", desc: "Random hex color", kind: "text", path: () => "/color" },
+
+            { cat: "Time", id: "ts", name: "timestamp", desc: "Current unix timestamp", kind: "json", path: () => "/timestamp" },
+            { cat: "Time", id: "ts2date", name: "timestamp → date", desc: "Unix timestamp to human date", kind: "json", inputs: [{ k: "unix", ph: "unix seconds or ms", def: "1781022640" }], path: v => `/timestamp/${encodeURIComponent(v.unix || 0)}` },
+            { cat: "Time", id: "utc", name: "time/utc", desc: "Current UTC time", kind: "json", path: () => "/time/utc" },
+            { cat: "Time", id: "tz", name: "time/{tz}", desc: "Time in an IANA timezone", kind: "json", inputs: [{ k: "tz", ph: "Asia/Dubai", def: "Asia/Dubai" }], path: v => `/time/${(v.tz || "UTC").split('/').map(encodeURIComponent).join('/')}` },
+            { cat: "Time", id: "dur", name: "duration", desc: "Humanize seconds → 1d 1h 1m", kind: "json", inputs: [{ k: "seconds", ph: "seconds", def: "90061" }], path: v => `/duration?seconds=${encodeURIComponent(v.seconds || 0)}` },
+
+            { cat: "Encoding", id: "b64e", name: "base64 encode", desc: "Text → base64", kind: "text", inputs: [{ k: "text", ph: "text", def: "hello world" }], path: v => `/base64/${encodeURIComponent(v.text || "")}` },
+            { cat: "Encoding", id: "b64d", name: "base64 decode", desc: "base64 → text", kind: "text", inputs: [{ k: "b64", ph: "base64", def: "aGVsbG8=" }], path: v => `/base64-decode/${encodeURIComponent(v.b64 || "")}` },
+            { cat: "Encoding", id: "b64ue", name: "base64url encode", desc: "URL-safe base64 (no padding)", kind: "text", inputs: [{ k: "text", ph: "text", def: "hello world" }], path: v => `/base64url/encode?text=${encodeURIComponent(v.text || "")}` },
+            { cat: "Encoding", id: "b64ud", name: "base64url decode", desc: "URL-safe base64 → text", kind: "text", inputs: [{ k: "input", ph: "base64url", def: "aGVsbG8gd29ybGQ" }], path: v => `/base64url/decode?input=${encodeURIComponent(v.input || "")}` },
+            { cat: "Encoding", id: "ue", name: "urlencode", desc: "Percent-encode text", kind: "text", inputs: [{ k: "text", ph: "text", def: "a b&c" }], path: v => `/urlencode/${encodeURIComponent(v.text || "")}` },
+            { cat: "Encoding", id: "ud", name: "urldecode", desc: "Decode percent-encoding", kind: "text", inputs: [{ k: "enc", ph: "encoded", def: "a%20b%26c" }], path: v => `/urldecode/${encodeURIComponent(v.enc || "")}` },
+            { cat: "Encoding", id: "hexe", name: "hex encode", desc: "Text → hex", kind: "text", inputs: [{ k: "text", ph: "text", def: "hi" }], path: v => `/hex/encode?text=${encodeURIComponent(v.text || "")}` },
+            { cat: "Encoding", id: "hexd", name: "hex decode", desc: "hex → text", kind: "text", inputs: [{ k: "input", ph: "hex", def: "6869" }], path: v => `/hex/decode?input=${encodeURIComponent(v.input || "")}` },
+            { cat: "Encoding", id: "rot13", name: "rot13", desc: "Caesar +13 (self-inverse)", kind: "text", inputs: [{ k: "text", ph: "text", def: "Hello" }], path: v => `/rot13?text=${encodeURIComponent(v.text || "")}` },
+            { cat: "Encoding", id: "htmle", name: "html encode", desc: "Escape HTML entities", kind: "text", inputs: [{ k: "text", ph: "<b>hi</b>", def: "<b>hi</b>" }], path: v => `/html/encode?text=${encodeURIComponent(v.text || "")}` },
+            { cat: "Encoding", id: "htmld", name: "html decode", desc: "Unescape HTML entities", kind: "text", inputs: [{ k: "text", ph: "&lt;b&gt;", def: "&lt;b&gt;hi&lt;/b&gt;" }], path: v => `/html/decode?text=${encodeURIComponent(v.text || "")}` },
+
+            { cat: "Crypto", id: "hash", name: "hash", desc: "md5 / sha1 / sha256", kind: "text", inputs: [{ k: "algo", ph: "md5|sha1|sha256", def: "sha256" }, { k: "text", ph: "text", def: "hello" }], path: v => `/hash/${encodeURIComponent(v.algo || "sha256")}/${encodeURIComponent(v.text || "")}` },
+            { cat: "Crypto", id: "jwt", name: "jwt-decode", desc: "Decode a JWT (no verify)", kind: "json", inputs: [{ k: "token", ph: "eyJ...", def: "" }], path: v => `/jwt-decode/${encodeURIComponent(v.token || "")}` },
+
+            { cat: "Text", id: "slug", name: "slugify", desc: "Make a URL slug", kind: "text", inputs: [{ k: "text", ph: "Hello World!", def: "Hello World!" }], path: v => `/text/slugify?text=${encodeURIComponent(v.text || "")}` },
+            { cat: "Text", id: "rev", name: "reverse", desc: "Reverse text", kind: "text", inputs: [{ k: "text", ph: "text", def: "stressed" }], path: v => `/text/reverse?text=${encodeURIComponent(v.text || "")}` },
+            { cat: "Text", id: "count", name: "count", desc: "Chars / words / lines", kind: "json", inputs: [{ k: "text", ph: "text", def: "the quick brown fox" }], path: v => `/text/count?text=${encodeURIComponent(v.text || "")}` },
+            { cat: "Text", id: "case", name: "case", desc: "upper/lower/title/snake/kebab/camel", kind: "text", inputs: [{ k: "mode", ph: "title", def: "title" }, { k: "text", ph: "text", def: "hello world" }], path: v => `/text/case/${encodeURIComponent(v.mode || "lower")}?text=${encodeURIComponent(v.text || "")}` },
+
+            { cat: "Convert", id: "base", name: "base convert", desc: "Number between bases 2-36", kind: "json", inputs: [{ k: "value", ph: "255", def: "255" }, { k: "from", ph: "from base", def: "10" }, { k: "to", ph: "to base", def: "16" }], path: v => `/base/convert?value=${encodeURIComponent(v.value || "0")}&from=${encodeURIComponent(v.from || 10)}&to=${encodeURIComponent(v.to || 16)}` },
+            { cat: "Convert", id: "h2r", name: "hex → rgb", desc: "Hex color to RGB", kind: "json", inputs: [{ k: "hex", ph: "ff8800", def: "ff8800" }], path: v => `/color/hex-to-rgb?hex=${encodeURIComponent(v.hex || "")}` },
+            { cat: "Convert", id: "r2h", name: "rgb → hex", desc: "RGB to hex color", kind: "json", inputs: [{ k: "r", ph: "r", def: "255" }, { k: "g", ph: "g", def: "136" }, { k: "b", ph: "b", def: "0" }], path: v => `/color/rgb-to-hex?r=${encodeURIComponent(v.r || 0)}&g=${encodeURIComponent(v.g || 0)}&b=${encodeURIComponent(v.b || 0)}` },
+
+            { cat: "Fun", id: "cat", name: "cat-fact", desc: "Random cat fact", kind: "text", path: () => "/cat-fact" },
+            { cat: "Fun", id: "quote", name: "quote", desc: "Random quote", kind: "text", path: () => "/quote" },
+            { cat: "Fun", id: "roll", name: "roll", desc: "Dice in NdM notation", kind: "json", inputs: [{ k: "dice", ph: "2d6", def: "2d6" }], path: v => `/roll/${encodeURIComponent(v.dice || "1d6")}` },
+            { cat: "Fun", id: "coin", name: "coinflip", desc: "Heads or tails", kind: "json", path: () => "/coinflip" },
+            { cat: "Fun", id: "8ball", name: "8ball", desc: "Magic 8-ball", kind: "json", path: () => "/8ball" },
+            { cat: "Fun", id: "pick", name: "pick", desc: "Random choice from a list", kind: "json", inputs: [{ k: "options", ph: "red,green,blue", def: "red,green,blue" }], path: v => `/pick?options=${encodeURIComponent(v.options || "")}` },
+
+            { cat: "QR", id: "qr", name: "qr", desc: "Generate an SVG QR code", kind: "svg", inputs: [{ k: "text", ph: "text or URL (max 1000)", def: "https://tools.stackfrost.com" }], path: v => `/qr?text=${encodeURIComponent(v.text || "")}` },
+        ];
+
+        const app = document.getElementById("app");
+        const cats = [...new Set(TOOLS.map(t => t.cat))];
+
+        function buildPath(tool) {
+            const vals = {};
+            (tool.inputs || []).forEach(inp => {
+                const el = document.getElementById(`in-${tool.id}-${inp.k}`);
+                vals[inp.k] = el ? el.value : "";
+            });
+            return tool.path(vals);
+        }
+
+        async function run(tool) {
+            const out = document.getElementById(`out-${tool.id}`);
+            const url = buildPath(tool);
+            out.className = "result show";
+            out.textContent = "…";
+            try {
+                const res = await fetch(url);
+                if (tool.kind === "svg") {
+                    const svg = await res.text();
+                    out.innerHTML = svg.trim().startsWith("<svg") ? svg : "";
+                    if (!out.innerHTML) { out.textContent = svg; out.classList.add("err"); }
+                    else { out.classList.remove("err"); }
+                    return;
+                }
+                const body = await res.text();
+                let rendered = body;
+                if (tool.kind === "json") {
+                    try { rendered = JSON.stringify(JSON.parse(body), null, 2); } catch (e) { /* leave raw */ }
+                }
+                out.textContent = rendered;
+                out.classList.toggle("err", !res.ok || /^Error:/.test(body) || /"error"/.test(body));
+            } catch (e) {
+                out.textContent = "Request failed: " + e.message;
+                out.classList.add("err");
+            }
+        }
+
+        cats.forEach(cat => {
+            const section = document.createElement("section");
+            section.className = "cat";
+            section.dataset.cat = cat;
+            section.innerHTML = `<h2>${cat}</h2>`;
+            const grid = document.createElement("div");
+            grid.className = "grid";
+
+            TOOLS.filter(t => t.cat === cat).forEach(tool => {
+                const card = document.createElement("div");
+                card.className = "card";
+                card.dataset.search = (tool.name + " " + tool.desc + " " + tool.cat).toLowerCase();
+
+                const inputsHtml = (tool.inputs || []).map(inp =>
+                    `<input id="in-${tool.id}-${inp.k}" placeholder="${inp.ph}" value="${inp.def ?? ""}">`
+                ).join("");
+
+                card.innerHTML =
+                    `<h3>${tool.name}</h3>
+                     <div class="desc">${tool.desc}</div>
+                     <div class="inputs">${inputsHtml}</div>
+                     <div class="row">
+                        <button class="run">Run</button>
+                        <a class="apilink" target="_blank">API ↗</a>
+                     </div>
+                     <div class="result" id="out-${tool.id}"></div>`;
+
+                const btn = card.querySelector("button.run");
+                const link = card.querySelector("a.apilink");
+                btn.addEventListener("click", () => run(tool));
+                const refreshLink = () => { link.href = buildPath(tool); };
+                refreshLink();
+                card.querySelectorAll("input").forEach(i => i.addEventListener("input", refreshLink));
+                card.querySelectorAll(".inputs input").forEach(i =>
+                    i.addEventListener("keydown", e => { if (e.key === "Enter") run(tool); }));
+
+                grid.appendChild(card);
+            });
+
+            section.appendChild(grid);
+            app.appendChild(section);
+        });
+
+        document.getElementById("count").textContent = TOOLS.length + " tools";
+
+        // Live filter
+        document.getElementById("search").addEventListener("input", e => {
+            const q = e.target.value.toLowerCase().trim();
+            document.querySelectorAll(".cat").forEach(sec => {
+                let visible = 0;
+                sec.querySelectorAll(".card").forEach(card => {
+                    const match = card.dataset.search.includes(q);
+                    card.style.display = match ? "" : "none";
+                    if (match) visible++;
+                });
+                sec.style.display = visible ? "" : "none";
+            });
+        });
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
## What

Extends the tools API with 18 new endpoints across time, text, encoding, conversion, fun, and QR — each available as both a **web form** (new interactive UI) and a **raw GET API**.

### New endpoints
- **Time:** `/timestamp/<unix>`, `/duration?seconds=`, and a real `/time/<tz>` using `chrono-tz` (previously a stub that ignored the timezone)
- **Text:** `/text/slugify`, `/text/reverse`, `/text/count`, `/text/case/<mode>` (upper/lower/title/snake/kebab/camel)
- **Encoding:** `/hex/encode|decode`, `/rot13`, `/html/encode|decode`, `/base64url/encode|decode`
- **Convert:** `/base/convert` (bases 2–36), `/color/hex-to-rgb`, `/color/rgb-to-hex`
- **Fun:** `/roll/<NdM>`, `/coinflip`, `/8ball`, `/pick?options=`
- **QR:** `/qr?text=` → SVG

### UI
`templates/index.html.hbs` is now an interactive, searchable single-page tool browser. Every card has inputs, a **Run** button, and an **API ↗** link to the raw endpoint.

### Abuse / DDoS protection (small 1 vCPU box)
- Per-endpoint input-size caps (text ≤10 KB, encoding ≤100 KB, QR text ≤1000 chars)
- Rocket request-body limits in `Rocket.toml`
- QR output dimensions clamped

### Tests
27 new integration tests dispatching against the real Rocket app via the local client (`cargo test` → 44 passing total). Covers happy paths, timezone resolution, roundtrips, bounds, error cases, and size caps.

### Dependencies
- `chrono-tz` (real timezones), `qrcode` (SVG-only, `default-features = false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)