### PR TITLE
Barcode + Data Matrix endpoints, UI overhaul (copy/dropdowns/rendered codes/QR composer)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.8"
 hex = "0.4"
 qrcode = { version = "0.14", default-features = false, features = ["svg"] }
+barcoders = { version = "2.0", default-features = false, features = ["svg"] }
+datamatrix = "=0.3.2"
 
 [dependencies.rocket]
 version = "0.5.0-rc.1"

--- a/src/endpoints/qr.rs
+++ b/src/endpoints/qr.rs
@@ -2,8 +2,17 @@ use qrcode::render::svg;
 use qrcode::QrCode;
 use rocket::http::ContentType;
 
-// SECURITY: hard cap on input so QR generation can't be used to burn CPU/memory.
+use barcoders::generators::svg::SVG as BarcodeSVG;
+use barcoders::sym::code39::Code39;
+use barcoders::sym::code128::Code128;
+use barcoders::sym::ean13::EAN13;
+
+use datamatrix::{DataMatrix, SymbolList};
+
+// SECURITY: hard caps on input so code generation can't be used to burn CPU/memory.
 const MAX_QR_TEXT: usize = 1_000;
+const MAX_BARCODE_TEXT: usize = 200;
+const MAX_DM_TEXT: usize = 500;
 
 /// `/qr?text=hello` -> an SVG QR code (Content-Type: image/svg+xml).
 #[get("/qr?<text>")]
@@ -31,4 +40,93 @@ pub fn qr(text: String) -> (ContentType, String) {
             "Error: input exceeds QR code capacity".to_string(),
         ),
     }
+}
+
+/// `/barcode?text=ABC123&symbology=code128` -> SVG 1D barcode.
+/// symbology: code128 (default), code39, ean13.
+#[get("/barcode?<text>&<symbology>")]
+pub fn barcode(text: String, symbology: Option<String>) -> (ContentType, String) {
+    if text.is_empty() {
+        return (ContentType::Plain, "Error: provide ?text=...".to_string());
+    }
+    if text.len() > MAX_BARCODE_TEXT {
+        return (
+            ContentType::Plain,
+            format!("Error: text too large (max {} chars)", MAX_BARCODE_TEXT),
+        );
+    }
+    let sym = symbology.unwrap_or_else(|| "code128".to_string()).to_lowercase();
+
+    let encoded: Result<Vec<u8>, String> = match sym.as_str() {
+        "code39" => Code39::new(&text)
+            .map(|b| b.encode())
+            .map_err(|_| "invalid data for Code39 (use A-Z, 0-9, space, -.$/+%)".to_string()),
+        "ean13" => EAN13::new(&text)
+            .map(|b| b.encode())
+            .map_err(|_| "invalid data for EAN-13 (use 12-13 digits)".to_string()),
+        "code128" => {
+            // Code128 in barcoders needs a leading code-set char; Ɓ = code set B (ASCII).
+            Code128::new(format!("\u{0181}{}", text))
+                .map(|b| b.encode())
+                .map_err(|_| "invalid data for Code128".to_string())
+        }
+        _ => return (ContentType::Plain, "Error: unknown symbology (code128, code39, ean13)".to_string()),
+    };
+
+    match encoded {
+        Ok(enc) => match BarcodeSVG::new(120).generate(&enc[..]) {
+            Ok(s) => {
+                // barcoders omits the SVG xmlns, which breaks <img>/standalone rendering.
+                let s = if s.contains("xmlns") {
+                    s
+                } else {
+                    s.replacen("<svg", "<svg xmlns=\"http://www.w3.org/2000/svg\"", 1)
+                };
+                (ContentType::SVG, s)
+            }
+            Err(_) => (ContentType::Plain, "Error: failed to render barcode".to_string()),
+        },
+        Err(msg) => (ContentType::Plain, format!("Error: {}", msg)),
+    }
+}
+
+/// `/datamatrix?text=hello` -> SVG Data Matrix (ECC 200).
+#[get("/datamatrix?<text>")]
+pub fn data_matrix(text: String) -> (ContentType, String) {
+    if text.is_empty() {
+        return (ContentType::Plain, "Error: provide ?text=...".to_string());
+    }
+    if text.len() > MAX_DM_TEXT {
+        return (
+            ContentType::Plain,
+            format!("Error: text too large (max {} chars)", MAX_DM_TEXT),
+        );
+    }
+    match DataMatrix::encode(text.as_bytes(), SymbolList::default()) {
+        Ok(code) => (ContentType::SVG, datamatrix_to_svg(&code)),
+        Err(_) => (ContentType::Plain, "Error: could not encode Data Matrix".to_string()),
+    }
+}
+
+fn datamatrix_to_svg(code: &datamatrix::DataMatrix) -> String {
+    let bitmap = code.bitmap();
+    let w = bitmap.width();
+    let h = bitmap.height();
+    let scale = 8usize;
+    let quiet = 1usize; // 1-module quiet zone
+    let total_w = (w + 2 * quiet) * scale;
+    let total_h = (h + 2 * quiet) * scale;
+    let mut rects = String::new();
+    for (x, y) in bitmap.pixels() {
+        let px = (x + quiet) * scale;
+        let py = (y + quiet) * scale;
+        rects.push_str(&format!(
+            "<rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\"/>",
+            px, py, scale, scale
+        ));
+    }
+    format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{}\" height=\"{}\" shape-rendering=\"crispEdges\"><rect width=\"100%\" height=\"100%\" fill=\"#fff\"/><g fill=\"#000\">{}</g></svg>",
+        total_w, total_h, rects
+    )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,8 @@ pub fn create_rocket() -> rocket::Rocket<rocket::Build> {
             fun::eight_ball,
             fun::pick,
             qr::qr,
+            qr::barcode,
+            qr::data_matrix,
         ])
 }
 
@@ -329,5 +331,62 @@ mod route_tests {
         let enc = get_text("/base64url/encode?text=hello%20world").1;
         let dec = get_text(&format!("/base64url/decode?input={}", enc)).1;
         assert_eq!(dec, "hello world");
+    }
+
+    // ---- barcode / data matrix ----
+    fn assert_svg(path: &str) {
+        let c = client();
+        let res = c.get(path).dispatch();
+        assert_eq!(res.status(), Status::Ok, "status for {}", path);
+        assert_eq!(res.content_type(), Some(ContentType::SVG), "content-type for {}", path);
+        let body = res.into_string().unwrap();
+        assert!(body.contains("<svg"), "no <svg in {}", path);
+        assert!(body.contains("xmlns"), "no xmlns in {} (won't render as <img>)", path);
+    }
+
+    #[test]
+    fn barcode_code128_is_svg_with_xmlns() {
+        assert_svg("/barcode?text=ABC-123");
+    }
+
+    #[test]
+    fn barcode_code39_is_svg() {
+        assert_svg("/barcode?text=HELLO&symbology=code39");
+    }
+
+    #[test]
+    fn barcode_ean13_valid_is_svg() {
+        assert_svg("/barcode?text=123456789012&symbology=ean13");
+    }
+
+    #[test]
+    fn barcode_ean13_rejects_letters() {
+        let (_, b) = get_text("/barcode?text=abc&symbology=ean13");
+        assert!(b.starts_with("Error:"));
+    }
+
+    #[test]
+    fn barcode_unknown_symbology_errors() {
+        let (_, b) = get_text("/barcode?text=ABC&symbology=nope");
+        assert!(b.starts_with("Error:"));
+    }
+
+    #[test]
+    fn barcode_rejects_oversized_input() {
+        let big = "A".repeat(300);
+        let (_, b) = get_text(&format!("/barcode?text={}", big));
+        assert!(b.starts_with("Error:"));
+    }
+
+    #[test]
+    fn datamatrix_is_svg_with_xmlns() {
+        assert_svg("/datamatrix?text=Hello%20DM");
+    }
+
+    #[test]
+    fn datamatrix_rejects_oversized_input() {
+        let big = "A".repeat(600);
+        let (_, b) = get_text(&format!("/datamatrix?text={}", big));
+        assert!(b.starts_with("Error:"));
     }
 }

--- a/templates/index.html.hbs
+++ b/templates/index.html.hbs
@@ -198,7 +198,10 @@
                 return `${lbl}<select id="${id}">${opts}</select>`;
             }
             const t = inp.type === "number" ? "number" : "text";
-            return `${lbl}<input id="${id}" type="${t}" placeholder="${inp.label || ""}" value="${inp.def != null ? inp.def : ""}">`;
+            // NOTE: default value is set via JS (.value) after render, not as an
+            // attribute — otherwise entity defaults like "&lt;b&gt;" get decoded by
+            // the HTML parser and the demo input would be wrong.
+            return `${lbl}<input id="${id}" type="${t}" placeholder="${inp.label || ""}">`;
         }
 
         function makeGenericCard(tool) {
@@ -213,6 +216,13 @@
                     <button class="iconbtn copyurl" title="Copy API URL">⧉</button></div>
                  <div class="reswrap"><button class="iconbtn copyres" title="Copy result" style="display:none">📋</button>
                     <div class="result"></div></div>`;
+            // set defaults via JS so entity strings aren't decoded by the attribute parser
+            (tool.inputs || []).forEach(inp => {
+                if (inp.def != null && inp.type !== "select") {
+                    const e = card.querySelector(`#in-${tool.id}-${inp.k}`);
+                    if (e) e.value = inp.def;
+                }
+            });
             const link = card.querySelector(".apilink");
             const refresh = () => { const u = apiURL(tool); link.href = u; link.textContent = u.replace(location.origin, ""); };
             refresh();
@@ -226,7 +236,7 @@
         // ---------- codes (image output) ----------
         const QR_TYPES = {
             text: { label: "Text", fields: [{ k: "text", ph: "Any text" }], build: v => v.text || "" },
-            url: { label: "URL", fields: [{ k: "url", ph: "https://example.com" }], build: v => v.url || "" },
+            url: { label: "URL", fields: [{ k: "url", ph: "https://example.com" }], build: v => { const u = (v.url || "").trim(); return u && !/^[a-z][a-z0-9+.\-]*:\/\//i.test(u) ? "https://" + u : u; } },
             phone: { label: "Phone", fields: [{ k: "phone", ph: "+1 555 123 4567" }], build: v => "tel:" + (v.phone || "").replace(/\s+/g, "") },
             email: { label: "Email", fields: [{ k: "email", ph: "name@example.com" }, { k: "subject", ph: "subject (optional)" }, { k: "body", ph: "body (optional)" }], build: v => { let s = "mailto:" + (v.email || ""); const q = []; if (v.subject) q.push("subject=" + enc(v.subject)); if (v.body) q.push("body=" + enc(v.body)); return s + (q.length ? "?" + q.join("&") : ""); } },
             sms: { label: "SMS", fields: [{ k: "phone", ph: "+1 555 123 4567" }, { k: "message", ph: "message (optional)" }], build: v => "SMSTO:" + (v.phone || "").replace(/\s+/g, "") + ":" + (v.message || "") },
@@ -235,20 +245,35 @@
             vcard: { label: "Contact (vCard)", fields: [{ k: "name", ph: "Full name" }, { k: "phone", ph: "phone" }, { k: "email", ph: "email" }], build: v => `MECARD:N:${v.name || ""};TEL:${v.phone || ""};EMAIL:${v.email || ""};;` },
         };
 
-        function renderImageResult(card, url) {
+        async function renderImageResult(card, url, filename) {
             const wrap = card.querySelector(".reswrap");
             const out = card.querySelector(".result");
-            wrap.classList.add("show");
-            out.className = "result img";
-            out.innerHTML = "";
-            const img = el("img", { src: url, alt: "generated code" });
-            img.onerror = () => { out.className = "result err"; out.textContent = "Failed to render — check your input."; };
-            const dl = el("a", { class: "dl", href: url, download: "code.svg" }, "⬇ Download SVG");
-            out.appendChild(img);
-            out.appendChild(dl);
             const apiLink = card.querySelector(".apilink");
             apiLink.href = url; apiLink.textContent = url.replace(location.origin, "");
             card.querySelector(".copyurl").onclick = e => copy(url, e.currentTarget);
+            wrap.classList.add("show");
+            out.className = "result";
+            out.textContent = "…";
+            try {
+                const res = await fetch(url);
+                const ct = res.headers.get("content-type") || "";
+                if (res.ok && ct.includes("svg")) {
+                    const svg = await res.text();
+                    const blobUrl = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml" }));
+                    out.className = "result img";
+                    out.innerHTML = "";
+                    out.appendChild(el("img", { src: blobUrl, alt: "generated code" }));
+                    out.appendChild(el("a", { class: "dl", href: url, download: filename || "code.svg" }, "⬇ Download SVG"));
+                } else {
+                    // surface the real server error (e.g. "invalid data for EAN-13")
+                    const body = await res.text();
+                    out.className = "result err";
+                    out.textContent = body || ("HTTP " + res.status);
+                }
+            } catch (e) {
+                out.className = "result err";
+                out.textContent = "Request failed: " + e.message;
+            }
         }
 
         function makeQRCard() {
@@ -285,7 +310,7 @@
             sel.addEventListener("change", () => { renderFields(); refresh(); bindFieldEvents(); });
             function bindFieldEvents() { fieldsBox.querySelectorAll("[data-k]").forEach(e => e.addEventListener("input", refresh)); }
             renderFields(); bindFieldEvents(); refresh();
-            card.querySelector(".run").addEventListener("click", () => renderImageResult(card, url()));
+            card.querySelector(".run").addEventListener("click", () => renderImageResult(card, url(), "qr.svg"));
             card.querySelector(".copyurl").addEventListener("click", e => copy(url(), e.currentTarget));
             return card;
         }
@@ -306,7 +331,7 @@
             const url = () => location.origin + `/barcode?text=${enc(txt.value)}&symbology=${enc(sym.value)}`;
             const refresh = () => { const u = url(); const a = card.querySelector(".apilink"); a.href = u; a.textContent = u.replace(location.origin, ""); };
             [sym, txt].forEach(e => e.addEventListener("input", refresh)); refresh();
-            card.querySelector(".run").addEventListener("click", () => renderImageResult(card, url()));
+            card.querySelector(".run").addEventListener("click", () => renderImageResult(card, url(), "barcode.svg"));
             card.querySelector(".copyurl").addEventListener("click", e => copy(url(), e.currentTarget));
             return card;
         }
@@ -325,7 +350,7 @@
             const url = () => location.origin + `/datamatrix?text=${enc(txt.value)}`;
             const refresh = () => { const u = url(); const a = card.querySelector(".apilink"); a.href = u; a.textContent = u.replace(location.origin, ""); };
             txt.addEventListener("input", refresh); refresh();
-            card.querySelector(".run").addEventListener("click", () => renderImageResult(card, url()));
+            card.querySelector(".run").addEventListener("click", () => renderImageResult(card, url(), "datamatrix.svg"));
             card.querySelector(".copyurl").addEventListener("click", e => copy(url(), e.currentTarget));
             return card;
         }

--- a/templates/index.html.hbs
+++ b/templates/index.html.hbs
@@ -5,92 +5,62 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tools · StackFrost</title>
-    <meta name="description" content="A small collection of developer utility endpoints — each usable as a web form or a JSON/text API.">
+    <meta name="description" content="Developer utility endpoints — usable as web forms or a JSON/text API.">
     <style>
         :root {
-            --bg: #0d1117;
-            --panel: #161b22;
-            --border: #21262d;
-            --text: #e6edf3;
-            --muted: #8b949e;
-            --accent: #58a6ff;
-            --accent-soft: rgba(88, 166, 255, 0.12);
-            --ok: #3fb950;
-            --radius: 12px;
+            --bg: #0d1117; --panel: #161b22; --border: #21262d; --text: #e6edf3;
+            --muted: #8b949e; --accent: #58a6ff; --accent-soft: rgba(88,166,255,.12);
+            --ok: #3fb950; --radius: 12px;
         }
-
         * { box-sizing: border-box; margin: 0; padding: 0; }
-
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-            background: var(--bg);
-            color: var(--text);
-            line-height: 1.5;
-            -webkit-font-smoothing: antialiased;
-            padding: 40px 20px 80px;
-        }
-
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background: var(--bg); color: var(--text); line-height: 1.5; -webkit-font-smoothing: antialiased; padding: 40px 20px 80px; }
         .wrap { max-width: 1100px; margin: 0 auto; }
-
-        header.page { margin-bottom: 28px; }
-        header.page h1 { font-size: 2rem; letter-spacing: -0.02em; }
-        header.page p { color: var(--muted); margin-top: 8px; max-width: 70ch; }
+        header.page h1 { font-size: 2rem; letter-spacing: -.02em; }
+        header.page p { color: var(--muted); margin-top: 8px; max-width: 72ch; }
         header.page code { color: var(--accent); }
-
-        .controls { display: flex; gap: 12px; flex-wrap: wrap; margin: 22px 0 8px; }
-        #search {
-            flex: 1; min-width: 220px;
-            background: var(--panel); border: 1px solid var(--border);
-            color: var(--text); border-radius: var(--radius);
-            padding: 10px 14px; font-size: 0.95rem;
-        }
+        .controls { margin: 22px 0 8px; }
+        #search { width: 100%; background: var(--panel); border: 1px solid var(--border); color: var(--text);
+            border-radius: var(--radius); padding: 10px 14px; font-size: .95rem; }
         #search:focus { outline: none; border-color: var(--accent); }
-
         .cat { margin-top: 34px; }
-        .cat h2 {
-            font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.12em;
-            color: var(--muted); font-weight: 600; margin-bottom: 14px;
-            border-bottom: 1px solid var(--border); padding-bottom: 8px;
-        }
-
-        .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 14px; }
-
-        .card {
-            background: var(--panel); border: 1px solid var(--border);
-            border-radius: var(--radius); padding: 16px;
-            display: flex; flex-direction: column; gap: 10px;
-        }
+        .cat h2 { font-size: .8rem; text-transform: uppercase; letter-spacing: .12em; color: var(--muted);
+            font-weight: 600; margin-bottom: 14px; border-bottom: 1px solid var(--border); padding-bottom: 8px; }
+        .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(330px, 1fr)); gap: 14px; }
+        .card { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius);
+            padding: 16px; display: flex; flex-direction: column; gap: 10px; }
         .card h3 { font-size: 1rem; font-weight: 600; }
-        .card .desc { color: var(--muted); font-size: 0.85rem; }
-        .card .path { font-family: Consolas, Monaco, monospace; font-size: 0.78rem; color: var(--accent); word-break: break-all; }
-
+        .card .desc { color: var(--muted); font-size: .85rem; }
         .inputs { display: flex; flex-direction: column; gap: 8px; }
-        .inputs input {
-            background: var(--bg); border: 1px solid var(--border); color: var(--text);
-            border-radius: 8px; padding: 8px 10px; font-size: 0.88rem; width: 100%;
-        }
-        .inputs input:focus { outline: none; border-color: var(--accent); }
-
-        .row { display: flex; gap: 8px; align-items: center; }
-        button.run {
-            background: var(--accent-soft); border: 1px solid var(--accent);
-            color: var(--accent); border-radius: 8px; padding: 8px 16px;
-            font-weight: 600; font-size: 0.85rem; cursor: pointer; transition: background .15s;
-        }
+        .inputs label { font-size: .72rem; color: var(--muted); margin-bottom: -4px; }
+        .inputs input, .inputs select { background: var(--bg); border: 1px solid var(--border); color: var(--text);
+            border-radius: 8px; padding: 8px 10px; font-size: .88rem; width: 100%; }
+        .inputs input:focus, .inputs select:focus { outline: none; border-color: var(--accent); }
+        .row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+        button.run { background: var(--accent-soft); border: 1px solid var(--accent); color: var(--accent);
+            border-radius: 8px; padding: 8px 16px; font-weight: 600; font-size: .85rem; cursor: pointer; transition: background .15s; }
         button.run:hover { background: var(--accent); color: #fff; }
-        a.apilink { color: var(--muted); font-size: 0.78rem; text-decoration: none; margin-left: auto; }
+        .iconbtn { background: var(--bg); border: 1px solid var(--border); color: var(--muted); border-radius: 8px;
+            padding: 6px 9px; font-size: .8rem; cursor: pointer; line-height: 1; }
+        .iconbtn:hover { border-color: var(--accent); color: var(--accent); }
+        a.apilink { color: var(--muted); font-size: .78rem; text-decoration: none; font-family: Consolas, Monaco, monospace;
+            overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%; }
         a.apilink:hover { color: var(--accent); text-decoration: underline; }
-
-        .result {
-            display: none; background: var(--bg); border: 1px solid var(--border);
-            border-radius: 8px; padding: 10px; font-family: Consolas, Monaco, monospace;
-            font-size: 0.8rem; white-space: pre-wrap; word-break: break-word; max-height: 280px; overflow: auto;
-        }
-        .result.show { display: block; }
+        .apirow { display: flex; gap: 6px; align-items: center; background: var(--bg); border: 1px solid var(--border);
+            border-radius: 8px; padding: 6px 8px; }
+        .apirow .lbl { color: var(--muted); font-size: .7rem; text-transform: uppercase; letter-spacing: .08em; }
+        .apirow a { flex: 1; }
+        .reswrap { position: relative; display: none; }
+        .reswrap.show { display: block; }
+        .reswrap .copyres { position: absolute; top: 6px; right: 6px; z-index: 2; }
+        .result { background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 10px;
+            font-family: Consolas, Monaco, monospace; font-size: .8rem; white-space: pre-wrap; word-break: break-word;
+            max-height: 300px; overflow: auto; }
         .result.err { border-color: #f85149; color: #ff7b72; }
-        .result svg { max-width: 220px; height: auto; background: #fff; border-radius: 6px; }
-
-        footer { margin-top: 60px; color: var(--muted); font-size: 0.8rem; text-align: center; }
+        .result.img { display: flex; flex-direction: column; align-items: center; gap: 8px; background: var(--bg); }
+        .result.img img { max-width: 260px; width: 100%; height: auto; background: #fff; border-radius: 6px; padding: 8px; }
+        .result.img .dl { font-size: .8rem; }
+        footer { margin-top: 60px; color: var(--muted); font-size: .8rem; text-align: center; }
         footer a { color: var(--accent); text-decoration: none; }
     </style>
 </head>
@@ -99,173 +69,299 @@
     <div class="wrap">
         <header class="page">
             <h1>🛠️ Tools</h1>
-            <p>A small collection of developer utilities. Every tool works as a form below <em>and</em> as a plain
-                <code>GET</code> API — click <strong>API ↗</strong> on any card to hit the raw endpoint.</p>
+            <p>A collection of developer utilities. Every tool works as a form <em>and</em> as a plain
+                <code>GET</code> API — the <strong>API URL</strong> under each tool updates live with your input
+                (fully URL-encoded), with a copy button so you can use it anywhere.</p>
         </header>
 
         <div class="controls">
-            <input id="search" type="search" placeholder="Filter tools… (e.g. base64, time, color)" autocomplete="off">
+            <input id="search" type="search" placeholder="Filter tools… (e.g. base64, qr, color)" autocomplete="off">
         </div>
 
         <div id="app"></div>
 
-        <footer>
-            <span id="count"></span> · built with Rust + Rocket ·
-            <a href="https://github.com/shahzaib-sheikh/tools-api">source</a>
-        </footer>
+        <footer><span id="count"></span> · built with Rust + Rocket ·
+            <a href="https://github.com/shahzaib-sheikh/tools-api">source</a></footer>
     </div>
 
     <script>
-        // Tool registry. Each tool: how to build its URL, its inputs, and how to render the response.
-        // kind: "json" | "text" | "svg"
+        // ---------- helpers ----------
+        const enc = encodeURIComponent;
+        function flash(btn, ok) {
+            const o = btn.textContent;
+            btn.textContent = ok ? "✓" : "✕";
+            setTimeout(() => { btn.textContent = o; }, 1100);
+        }
+        function copy(text, btn) {
+            navigator.clipboard.writeText(text).then(() => flash(btn, true)).catch(() => flash(btn, false));
+        }
+        function el(tag, attrs, html) {
+            const e = document.createElement(tag);
+            if (attrs) for (const k in attrs) e.setAttribute(k, attrs[k]);
+            if (html != null) e.innerHTML = html;
+            return e;
+        }
+
+        // ---------- generic tool registry ----------
+        // input def: {k, label, ph, def, type:"text"|"number"|"select", options:[[value,label],...]}
         const TOOLS = [
             { cat: "Request", id: "whoami", name: "whoami", desc: "Your IP, headers & cookies", kind: "json", path: () => "/whoami" },
-            { cat: "Request", id: "ip", name: "ip", desc: "Your public IP address", kind: "text", path: () => "/ip" },
+            { cat: "Request", id: "ip", name: "ip", desc: "Your public IP", kind: "text", path: () => "/ip" },
             { cat: "Request", id: "headers", name: "headers", desc: "All request headers", kind: "json", path: () => "/headers" },
-            { cat: "Request", id: "ua", name: "user-agent", desc: "Your user agent string", kind: "text", path: () => "/user-agent" },
+            { cat: "Request", id: "ua", name: "user-agent", desc: "Your user agent", kind: "text", path: () => "/user-agent" },
             { cat: "Request", id: "ping", name: "ping", desc: "Health check → pong", kind: "text", path: () => "/ping" },
 
             { cat: "Generators", id: "uuid", name: "uuid", desc: "Random UUID v4", kind: "text", path: () => "/uuid" },
-            { cat: "Generators", id: "pw", name: "password", desc: "Secure random password", kind: "text", inputs: [{ k: "length", ph: "length (1-128)", def: "20" }], path: v => `/password/${encodeURIComponent(v.length || 16)}` },
-            { cat: "Generators", id: "lorem", name: "lorem", desc: "Lorem ipsum words", kind: "text", inputs: [{ k: "words", ph: "word count (1-1000)", def: "20" }], path: v => `/lorem/${encodeURIComponent(v.words || 10)}` },
-            { cat: "Generators", id: "num", name: "number", desc: "Random number in range", kind: "text", inputs: [{ k: "min", ph: "min", def: "1" }, { k: "max", ph: "max", def: "100" }], path: v => `/number/${encodeURIComponent(v.min || 0)}/${encodeURIComponent(v.max || 100)}` },
+            { cat: "Generators", id: "pw", name: "password", desc: "Secure random password", kind: "text", inputs: [{ k: "length", label: "length (1-128)", type: "number", def: "20" }], path: v => `/password/${enc(v.length || 16)}` },
+            { cat: "Generators", id: "lorem", name: "lorem", desc: "Lorem ipsum words", kind: "text", inputs: [{ k: "words", label: "word count (1-1000)", type: "number", def: "20" }], path: v => `/lorem/${enc(v.words || 10)}` },
+            { cat: "Generators", id: "num", name: "number", desc: "Random number in range", kind: "text", inputs: [{ k: "min", label: "min", type: "number", def: "1" }, { k: "max", label: "max", type: "number", def: "100" }], path: v => `/number/${enc(v.min || 0)}/${enc(v.max || 100)}` },
             { cat: "Generators", id: "color", name: "color", desc: "Random hex color", kind: "text", path: () => "/color" },
 
             { cat: "Time", id: "ts", name: "timestamp", desc: "Current unix timestamp", kind: "json", path: () => "/timestamp" },
-            { cat: "Time", id: "ts2date", name: "timestamp → date", desc: "Unix timestamp to human date", kind: "json", inputs: [{ k: "unix", ph: "unix seconds or ms", def: "1781022640" }], path: v => `/timestamp/${encodeURIComponent(v.unix || 0)}` },
+            { cat: "Time", id: "ts2date", name: "timestamp → date", desc: "Unix timestamp to date", kind: "json", inputs: [{ k: "unix", label: "unix (s or ms)", def: "1781022640" }], path: v => `/timestamp/${enc(v.unix || 0)}` },
             { cat: "Time", id: "utc", name: "time/utc", desc: "Current UTC time", kind: "json", path: () => "/time/utc" },
-            { cat: "Time", id: "tz", name: "time/{tz}", desc: "Time in an IANA timezone", kind: "json", inputs: [{ k: "tz", ph: "Asia/Dubai", def: "Asia/Dubai" }], path: v => `/time/${(v.tz || "UTC").split('/').map(encodeURIComponent).join('/')}` },
-            { cat: "Time", id: "dur", name: "duration", desc: "Humanize seconds → 1d 1h 1m", kind: "json", inputs: [{ k: "seconds", ph: "seconds", def: "90061" }], path: v => `/duration?seconds=${encodeURIComponent(v.seconds || 0)}` },
+            { cat: "Time", id: "tz", name: "time/{tz}", desc: "Time in an IANA timezone", kind: "json", inputs: [{ k: "tz", label: "timezone", def: "Asia/Dubai" }], path: v => `/time/${(v.tz || "UTC").split("/").map(enc).join("/")}` },
+            { cat: "Time", id: "dur", name: "duration", desc: "Humanize seconds", kind: "json", inputs: [{ k: "seconds", label: "seconds", type: "number", def: "90061" }], path: v => `/duration?seconds=${enc(v.seconds || 0)}` },
 
-            { cat: "Encoding", id: "b64e", name: "base64 encode", desc: "Text → base64", kind: "text", inputs: [{ k: "text", ph: "text", def: "hello world" }], path: v => `/base64/${encodeURIComponent(v.text || "")}` },
-            { cat: "Encoding", id: "b64d", name: "base64 decode", desc: "base64 → text", kind: "text", inputs: [{ k: "b64", ph: "base64", def: "aGVsbG8=" }], path: v => `/base64-decode/${encodeURIComponent(v.b64 || "")}` },
-            { cat: "Encoding", id: "b64ue", name: "base64url encode", desc: "URL-safe base64 (no padding)", kind: "text", inputs: [{ k: "text", ph: "text", def: "hello world" }], path: v => `/base64url/encode?text=${encodeURIComponent(v.text || "")}` },
-            { cat: "Encoding", id: "b64ud", name: "base64url decode", desc: "URL-safe base64 → text", kind: "text", inputs: [{ k: "input", ph: "base64url", def: "aGVsbG8gd29ybGQ" }], path: v => `/base64url/decode?input=${encodeURIComponent(v.input || "")}` },
-            { cat: "Encoding", id: "ue", name: "urlencode", desc: "Percent-encode text", kind: "text", inputs: [{ k: "text", ph: "text", def: "a b&c" }], path: v => `/urlencode/${encodeURIComponent(v.text || "")}` },
-            { cat: "Encoding", id: "ud", name: "urldecode", desc: "Decode percent-encoding", kind: "text", inputs: [{ k: "enc", ph: "encoded", def: "a%20b%26c" }], path: v => `/urldecode/${encodeURIComponent(v.enc || "")}` },
-            { cat: "Encoding", id: "hexe", name: "hex encode", desc: "Text → hex", kind: "text", inputs: [{ k: "text", ph: "text", def: "hi" }], path: v => `/hex/encode?text=${encodeURIComponent(v.text || "")}` },
-            { cat: "Encoding", id: "hexd", name: "hex decode", desc: "hex → text", kind: "text", inputs: [{ k: "input", ph: "hex", def: "6869" }], path: v => `/hex/decode?input=${encodeURIComponent(v.input || "")}` },
-            { cat: "Encoding", id: "rot13", name: "rot13", desc: "Caesar +13 (self-inverse)", kind: "text", inputs: [{ k: "text", ph: "text", def: "Hello" }], path: v => `/rot13?text=${encodeURIComponent(v.text || "")}` },
-            { cat: "Encoding", id: "htmle", name: "html encode", desc: "Escape HTML entities", kind: "text", inputs: [{ k: "text", ph: "<b>hi</b>", def: "<b>hi</b>" }], path: v => `/html/encode?text=${encodeURIComponent(v.text || "")}` },
-            { cat: "Encoding", id: "htmld", name: "html decode", desc: "Unescape HTML entities", kind: "text", inputs: [{ k: "text", ph: "&lt;b&gt;", def: "&lt;b&gt;hi&lt;/b&gt;" }], path: v => `/html/decode?text=${encodeURIComponent(v.text || "")}` },
+            { cat: "Encoding", id: "b64e", name: "base64 encode", desc: "Text → base64", kind: "text", inputs: [{ k: "text", label: "text", def: "hello world" }], path: v => `/base64/${enc(v.text || "")}` },
+            { cat: "Encoding", id: "b64d", name: "base64 decode", desc: "base64 → text", kind: "text", inputs: [{ k: "b64", label: "base64", def: "aGVsbG8=" }], path: v => `/base64-decode/${enc(v.b64 || "")}` },
+            { cat: "Encoding", id: "b64ue", name: "base64url encode", desc: "URL-safe base64", kind: "text", inputs: [{ k: "text", label: "text", def: "hello world" }], path: v => `/base64url/encode?text=${enc(v.text || "")}` },
+            { cat: "Encoding", id: "b64ud", name: "base64url decode", desc: "URL-safe base64 → text", kind: "text", inputs: [{ k: "input", label: "base64url", def: "aGVsbG8gd29ybGQ" }], path: v => `/base64url/decode?input=${enc(v.input || "")}` },
+            { cat: "Encoding", id: "ue", name: "urlencode", desc: "Percent-encode", kind: "text", inputs: [{ k: "text", label: "text", def: "a b&c" }], path: v => `/urlencode/${enc(v.text || "")}` },
+            { cat: "Encoding", id: "ud", name: "urldecode", desc: "Decode percent-encoding", kind: "text", inputs: [{ k: "enc", label: "encoded", def: "a%20b%26c" }], path: v => `/urldecode/${enc(v.enc || "")}` },
+            { cat: "Encoding", id: "hexe", name: "hex encode", desc: "Text → hex", kind: "text", inputs: [{ k: "text", label: "text", def: "hi" }], path: v => `/hex/encode?text=${enc(v.text || "")}` },
+            { cat: "Encoding", id: "hexd", name: "hex decode", desc: "hex → text", kind: "text", inputs: [{ k: "input", label: "hex", def: "6869" }], path: v => `/hex/decode?input=${enc(v.input || "")}` },
+            { cat: "Encoding", id: "rot13", name: "rot13", desc: "Caesar +13", kind: "text", inputs: [{ k: "text", label: "text", def: "Hello" }], path: v => `/rot13?text=${enc(v.text || "")}` },
+            { cat: "Encoding", id: "htmle", name: "html encode", desc: "Escape HTML entities", kind: "text", inputs: [{ k: "text", label: "text", def: "<b>hi</b>" }], path: v => `/html/encode?text=${enc(v.text || "")}` },
+            { cat: "Encoding", id: "htmld", name: "html decode", desc: "Unescape HTML entities", kind: "text", inputs: [{ k: "text", label: "text", def: "&lt;b&gt;hi&lt;/b&gt;" }], path: v => `/html/decode?text=${enc(v.text || "")}` },
 
-            { cat: "Crypto", id: "hash", name: "hash", desc: "md5 / sha1 / sha256", kind: "text", inputs: [{ k: "algo", ph: "md5|sha1|sha256", def: "sha256" }, { k: "text", ph: "text", def: "hello" }], path: v => `/hash/${encodeURIComponent(v.algo || "sha256")}/${encodeURIComponent(v.text || "")}` },
-            { cat: "Crypto", id: "jwt", name: "jwt-decode", desc: "Decode a JWT (no verify)", kind: "json", inputs: [{ k: "token", ph: "eyJ...", def: "" }], path: v => `/jwt-decode/${encodeURIComponent(v.token || "")}` },
+            { cat: "Crypto", id: "hash", name: "hash", desc: "Hash text", kind: "text", inputs: [{ k: "algo", label: "algorithm", type: "select", options: [["sha256", "sha256"], ["sha1", "sha1"], ["md5", "md5"]] }, { k: "text", label: "text", def: "hello" }], path: v => `/hash/${enc(v.algo || "sha256")}/${enc(v.text || "")}` },
+            { cat: "Crypto", id: "jwt", name: "jwt-decode", desc: "Decode a JWT (no verify)", kind: "json", inputs: [{ k: "token", label: "token", def: "" }], path: v => `/jwt-decode/${enc(v.token || "")}` },
 
-            { cat: "Text", id: "slug", name: "slugify", desc: "Make a URL slug", kind: "text", inputs: [{ k: "text", ph: "Hello World!", def: "Hello World!" }], path: v => `/text/slugify?text=${encodeURIComponent(v.text || "")}` },
-            { cat: "Text", id: "rev", name: "reverse", desc: "Reverse text", kind: "text", inputs: [{ k: "text", ph: "text", def: "stressed" }], path: v => `/text/reverse?text=${encodeURIComponent(v.text || "")}` },
-            { cat: "Text", id: "count", name: "count", desc: "Chars / words / lines", kind: "json", inputs: [{ k: "text", ph: "text", def: "the quick brown fox" }], path: v => `/text/count?text=${encodeURIComponent(v.text || "")}` },
-            { cat: "Text", id: "case", name: "case", desc: "upper/lower/title/snake/kebab/camel", kind: "text", inputs: [{ k: "mode", ph: "title", def: "title" }, { k: "text", ph: "text", def: "hello world" }], path: v => `/text/case/${encodeURIComponent(v.mode || "lower")}?text=${encodeURIComponent(v.text || "")}` },
+            { cat: "Text", id: "slug", name: "slugify", desc: "Make a URL slug", kind: "text", inputs: [{ k: "text", label: "text", def: "Hello World!" }], path: v => `/text/slugify?text=${enc(v.text || "")}` },
+            { cat: "Text", id: "rev", name: "reverse", desc: "Reverse text", kind: "text", inputs: [{ k: "text", label: "text", def: "stressed" }], path: v => `/text/reverse?text=${enc(v.text || "")}` },
+            { cat: "Text", id: "count", name: "count", desc: "Chars / words / lines", kind: "json", inputs: [{ k: "text", label: "text", def: "the quick brown fox" }], path: v => `/text/count?text=${enc(v.text || "")}` },
+            { cat: "Text", id: "case", name: "case", desc: "Change letter case", kind: "text", inputs: [{ k: "mode", label: "mode", type: "select", options: [["upper", "UPPER"], ["lower", "lower"], ["title", "Title"], ["snake", "snake_case"], ["kebab", "kebab-case"], ["camel", "camelCase"]] }, { k: "text", label: "text", def: "hello world" }], path: v => `/text/case/${enc(v.mode || "lower")}?text=${enc(v.text || "")}` },
 
-            { cat: "Convert", id: "base", name: "base convert", desc: "Number between bases 2-36", kind: "json", inputs: [{ k: "value", ph: "255", def: "255" }, { k: "from", ph: "from base", def: "10" }, { k: "to", ph: "to base", def: "16" }], path: v => `/base/convert?value=${encodeURIComponent(v.value || "0")}&from=${encodeURIComponent(v.from || 10)}&to=${encodeURIComponent(v.to || 16)}` },
-            { cat: "Convert", id: "h2r", name: "hex → rgb", desc: "Hex color to RGB", kind: "json", inputs: [{ k: "hex", ph: "ff8800", def: "ff8800" }], path: v => `/color/hex-to-rgb?hex=${encodeURIComponent(v.hex || "")}` },
-            { cat: "Convert", id: "r2h", name: "rgb → hex", desc: "RGB to hex color", kind: "json", inputs: [{ k: "r", ph: "r", def: "255" }, { k: "g", ph: "g", def: "136" }, { k: "b", ph: "b", def: "0" }], path: v => `/color/rgb-to-hex?r=${encodeURIComponent(v.r || 0)}&g=${encodeURIComponent(v.g || 0)}&b=${encodeURIComponent(v.b || 0)}` },
+            { cat: "Convert", id: "base", name: "base convert", desc: "Number between bases 2-36", kind: "json", inputs: [{ k: "value", label: "value", def: "255" }, { k: "from", label: "from base", type: "number", def: "10" }, { k: "to", label: "to base", type: "number", def: "16" }], path: v => `/base/convert?value=${enc(v.value || "0")}&from=${enc(v.from || 10)}&to=${enc(v.to || 16)}` },
+            { cat: "Convert", id: "h2r", name: "hex → rgb", desc: "Hex color to RGB", kind: "json", inputs: [{ k: "hex", label: "hex", def: "ff8800" }], path: v => `/color/hex-to-rgb?hex=${enc(v.hex || "")}` },
+            { cat: "Convert", id: "r2h", name: "rgb → hex", desc: "RGB to hex", kind: "json", inputs: [{ k: "r", label: "r", type: "number", def: "255" }, { k: "g", label: "g", type: "number", def: "136" }, { k: "b", label: "b", type: "number", def: "0" }], path: v => `/color/rgb-to-hex?r=${enc(v.r || 0)}&g=${enc(v.g || 0)}&b=${enc(v.b || 0)}` },
 
             { cat: "Fun", id: "cat", name: "cat-fact", desc: "Random cat fact", kind: "text", path: () => "/cat-fact" },
             { cat: "Fun", id: "quote", name: "quote", desc: "Random quote", kind: "text", path: () => "/quote" },
-            { cat: "Fun", id: "roll", name: "roll", desc: "Dice in NdM notation", kind: "json", inputs: [{ k: "dice", ph: "2d6", def: "2d6" }], path: v => `/roll/${encodeURIComponent(v.dice || "1d6")}` },
+            { cat: "Fun", id: "roll", name: "roll", desc: "Dice in NdM notation", kind: "json", inputs: [{ k: "dice", label: "dice", def: "2d6" }], path: v => `/roll/${enc(v.dice || "1d6")}` },
             { cat: "Fun", id: "coin", name: "coinflip", desc: "Heads or tails", kind: "json", path: () => "/coinflip" },
             { cat: "Fun", id: "8ball", name: "8ball", desc: "Magic 8-ball", kind: "json", path: () => "/8ball" },
-            { cat: "Fun", id: "pick", name: "pick", desc: "Random choice from a list", kind: "json", inputs: [{ k: "options", ph: "red,green,blue", def: "red,green,blue" }], path: v => `/pick?options=${encodeURIComponent(v.options || "")}` },
-
-            { cat: "QR", id: "qr", name: "qr", desc: "Generate an SVG QR code", kind: "svg", inputs: [{ k: "text", ph: "text or URL (max 1000)", def: "https://tools.stackfrost.com" }], path: v => `/qr?text=${encodeURIComponent(v.text || "")}` },
+            { cat: "Fun", id: "pick", name: "pick", desc: "Random choice from a list", kind: "json", inputs: [{ k: "options", label: "options (comma-sep)", def: "red,green,blue" }], path: v => `/pick?options=${enc(v.options || "")}` },
         ];
 
-        const app = document.getElementById("app");
-        const cats = [...new Set(TOOLS.map(t => t.cat))];
-
-        function buildPath(tool) {
-            const vals = {};
+        // ---------- generic engine ----------
+        function readInputs(tool) {
+            const v = {};
             (tool.inputs || []).forEach(inp => {
-                const el = document.getElementById(`in-${tool.id}-${inp.k}`);
-                vals[inp.k] = el ? el.value : "";
+                const e = document.getElementById(`in-${tool.id}-${inp.k}`);
+                v[inp.k] = e ? e.value : "";
             });
-            return tool.path(vals);
+            return v;
         }
+        function apiURL(tool) { return location.origin + tool.path(readInputs(tool)); }
 
-        async function run(tool) {
-            const out = document.getElementById(`out-${tool.id}`);
-            const url = buildPath(tool);
-            out.className = "result show";
+        async function runTool(tool, card) {
+            const wrap = card.querySelector(".reswrap");
+            const out = card.querySelector(".result");
+            const copyRes = card.querySelector(".copyres");
+            wrap.classList.add("show");
+            out.className = "result";
             out.textContent = "…";
+            copyRes.style.display = "none";
             try {
-                const res = await fetch(url);
-                if (tool.kind === "svg") {
-                    const svg = await res.text();
-                    out.innerHTML = svg.trim().startsWith("<svg") ? svg : "";
-                    if (!out.innerHTML) { out.textContent = svg; out.classList.add("err"); }
-                    else { out.classList.remove("err"); }
-                    return;
-                }
+                const res = await fetch(tool.path(readInputs(tool)));
                 const body = await res.text();
-                let rendered = body;
-                if (tool.kind === "json") {
-                    try { rendered = JSON.stringify(JSON.parse(body), null, 2); } catch (e) { /* leave raw */ }
-                }
-                out.textContent = rendered;
-                out.classList.toggle("err", !res.ok || /^Error:/.test(body) || /"error"/.test(body));
+                let shown = body;
+                if (tool.kind === "json") { try { shown = JSON.stringify(JSON.parse(body), null, 2); } catch (e) {} }
+                out.textContent = shown;
+                const bad = !res.ok || /^Error:/.test(body) || /"error"\s*:/.test(body);
+                out.classList.toggle("err", bad);
+                copyRes.style.display = "inline-block";
+                copyRes.onclick = () => copy(shown, copyRes);
             } catch (e) {
                 out.textContent = "Request failed: " + e.message;
                 out.classList.add("err");
             }
         }
 
+        function inputHTML(tool, inp) {
+            const id = `in-${tool.id}-${inp.k}`;
+            const lbl = inp.label ? `<label for="${id}">${inp.label}</label>` : "";
+            if (inp.type === "select") {
+                const opts = inp.options.map(o => `<option value="${o[0]}">${o[1]}</option>`).join("");
+                return `${lbl}<select id="${id}">${opts}</select>`;
+            }
+            const t = inp.type === "number" ? "number" : "text";
+            return `${lbl}<input id="${id}" type="${t}" placeholder="${inp.label || ""}" value="${inp.def != null ? inp.def : ""}">`;
+        }
+
+        function makeGenericCard(tool) {
+            const card = el("div", { class: "card" });
+            card.dataset.search = (tool.name + " " + tool.desc + " " + tool.cat).toLowerCase();
+            const inputs = (tool.inputs || []).map(i => inputHTML(tool, i)).join("");
+            card.innerHTML =
+                `<h3>${tool.name}</h3><div class="desc">${tool.desc}</div>
+                 <div class="inputs">${inputs}</div>
+                 <div class="row"><button class="run">Run</button></div>
+                 <div class="apirow"><span class="lbl">API</span><a class="apilink" target="_blank"></a>
+                    <button class="iconbtn copyurl" title="Copy API URL">⧉</button></div>
+                 <div class="reswrap"><button class="iconbtn copyres" title="Copy result" style="display:none">📋</button>
+                    <div class="result"></div></div>`;
+            const link = card.querySelector(".apilink");
+            const refresh = () => { const u = apiURL(tool); link.href = u; link.textContent = u.replace(location.origin, ""); };
+            refresh();
+            card.querySelectorAll("input,select").forEach(i => i.addEventListener("input", refresh));
+            card.querySelector(".run").addEventListener("click", () => runTool(tool, card));
+            card.querySelector(".copyurl").addEventListener("click", e => copy(apiURL(tool), e.currentTarget));
+            card.querySelectorAll(".inputs input").forEach(i => i.addEventListener("keydown", e => { if (e.key === "Enter") runTool(tool, card); }));
+            return card;
+        }
+
+        // ---------- codes (image output) ----------
+        const QR_TYPES = {
+            text: { label: "Text", fields: [{ k: "text", ph: "Any text" }], build: v => v.text || "" },
+            url: { label: "URL", fields: [{ k: "url", ph: "https://example.com" }], build: v => v.url || "" },
+            phone: { label: "Phone", fields: [{ k: "phone", ph: "+1 555 123 4567" }], build: v => "tel:" + (v.phone || "").replace(/\s+/g, "") },
+            email: { label: "Email", fields: [{ k: "email", ph: "name@example.com" }, { k: "subject", ph: "subject (optional)" }, { k: "body", ph: "body (optional)" }], build: v => { let s = "mailto:" + (v.email || ""); const q = []; if (v.subject) q.push("subject=" + enc(v.subject)); if (v.body) q.push("body=" + enc(v.body)); return s + (q.length ? "?" + q.join("&") : ""); } },
+            sms: { label: "SMS", fields: [{ k: "phone", ph: "+1 555 123 4567" }, { k: "message", ph: "message (optional)" }], build: v => "SMSTO:" + (v.phone || "").replace(/\s+/g, "") + ":" + (v.message || "") },
+            wifi: { label: "WiFi", fields: [{ k: "ssid", ph: "network name" }, { k: "password", ph: "password" }, { k: "encryption", type: "select", options: [["WPA", "WPA/WPA2"], ["WEP", "WEP"], ["nopass", "No password"]] }], build: v => { const esc = s => (s || "").replace(/([\\;,:"])/g, "\\$1"); const t = v.encryption || "WPA"; return t === "nopass" ? `WIFI:T:nopass;S:${esc(v.ssid)};;` : `WIFI:T:${t};S:${esc(v.ssid)};P:${esc(v.password)};;`; } },
+            geo: { label: "Geo location", fields: [{ k: "lat", ph: "latitude" }, { k: "lng", ph: "longitude" }], build: v => `geo:${v.lat || 0},${v.lng || 0}` },
+            vcard: { label: "Contact (vCard)", fields: [{ k: "name", ph: "Full name" }, { k: "phone", ph: "phone" }, { k: "email", ph: "email" }], build: v => `MECARD:N:${v.name || ""};TEL:${v.phone || ""};EMAIL:${v.email || ""};;` },
+        };
+
+        function renderImageResult(card, url) {
+            const wrap = card.querySelector(".reswrap");
+            const out = card.querySelector(".result");
+            wrap.classList.add("show");
+            out.className = "result img";
+            out.innerHTML = "";
+            const img = el("img", { src: url, alt: "generated code" });
+            img.onerror = () => { out.className = "result err"; out.textContent = "Failed to render — check your input."; };
+            const dl = el("a", { class: "dl", href: url, download: "code.svg" }, "⬇ Download SVG");
+            out.appendChild(img);
+            out.appendChild(dl);
+            const apiLink = card.querySelector(".apilink");
+            apiLink.href = url; apiLink.textContent = url.replace(location.origin, "");
+            card.querySelector(".copyurl").onclick = e => copy(url, e.currentTarget);
+        }
+
+        function makeQRCard() {
+            const card = el("div", { class: "card" });
+            card.dataset.search = "qr code generator url phone email sms wifi geo vcard contact";
+            const typeOpts = Object.keys(QR_TYPES).map(k => `<option value="${k}">${QR_TYPES[k].label}</option>`).join("");
+            card.innerHTML =
+                `<h3>QR code</h3><div class="desc">Generate a QR for any content type</div>
+                 <div class="inputs"><label>type</label><select class="qrtype">${typeOpts}</select>
+                    <div class="qrfields"></div></div>
+                 <div class="row"><button class="run">Generate</button></div>
+                 <div class="apirow"><span class="lbl">API</span><a class="apilink" target="_blank"></a>
+                    <button class="iconbtn copyurl" title="Copy API URL">⧉</button></div>
+                 <div class="reswrap"><div class="result"></div></div>`;
+            const sel = card.querySelector(".qrtype");
+            const fieldsBox = card.querySelector(".qrfields");
+            function renderFields() {
+                const t = QR_TYPES[sel.value];
+                fieldsBox.innerHTML = t.fields.map(f => {
+                    if (f.type === "select") {
+                        const o = f.options.map(x => `<option value="${x[0]}">${x[1]}</option>`).join("");
+                        return `<label>${f.k}</label><select data-k="${f.k}">${o}</select>`;
+                    }
+                    return `<label>${f.k}</label><input data-k="${f.k}" placeholder="${f.ph || ""}">`;
+                }).join("");
+            }
+            function payload() {
+                const t = QR_TYPES[sel.value]; const v = {};
+                fieldsBox.querySelectorAll("[data-k]").forEach(e => v[e.dataset.k] = e.value);
+                return t.build(v);
+            }
+            function url() { return location.origin + "/qr?text=" + enc(payload()); }
+            function refresh() { const u = url(); const a = card.querySelector(".apilink"); a.href = u; a.textContent = u.replace(location.origin, ""); }
+            sel.addEventListener("change", () => { renderFields(); refresh(); bindFieldEvents(); });
+            function bindFieldEvents() { fieldsBox.querySelectorAll("[data-k]").forEach(e => e.addEventListener("input", refresh)); }
+            renderFields(); bindFieldEvents(); refresh();
+            card.querySelector(".run").addEventListener("click", () => renderImageResult(card, url()));
+            card.querySelector(".copyurl").addEventListener("click", e => copy(url(), e.currentTarget));
+            return card;
+        }
+
+        function makeBarcodeCard() {
+            const card = el("div", { class: "card" });
+            card.dataset.search = "barcode code128 code39 ean13 1d";
+            card.innerHTML =
+                `<h3>Barcode</h3><div class="desc">1D barcode (Code128 / Code39 / EAN-13)</div>
+                 <div class="inputs"><label>symbology</label>
+                    <select class="bsym"><option value="code128">Code 128</option><option value="code39">Code 39</option><option value="ean13">EAN-13</option></select>
+                    <label>data</label><input class="btext" placeholder="ABC-123" value="ABC-123"></div>
+                 <div class="row"><button class="run">Generate</button></div>
+                 <div class="apirow"><span class="lbl">API</span><a class="apilink" target="_blank"></a>
+                    <button class="iconbtn copyurl" title="Copy API URL">⧉</button></div>
+                 <div class="reswrap"><div class="result"></div></div>`;
+            const sym = card.querySelector(".bsym"), txt = card.querySelector(".btext");
+            const url = () => location.origin + `/barcode?text=${enc(txt.value)}&symbology=${enc(sym.value)}`;
+            const refresh = () => { const u = url(); const a = card.querySelector(".apilink"); a.href = u; a.textContent = u.replace(location.origin, ""); };
+            [sym, txt].forEach(e => e.addEventListener("input", refresh)); refresh();
+            card.querySelector(".run").addEventListener("click", () => renderImageResult(card, url()));
+            card.querySelector(".copyurl").addEventListener("click", e => copy(url(), e.currentTarget));
+            return card;
+        }
+
+        function makeDataMatrixCard() {
+            const card = el("div", { class: "card" });
+            card.dataset.search = "data matrix datamatrix 2d ecc200";
+            card.innerHTML =
+                `<h3>Data Matrix</h3><div class="desc">2D Data Matrix (ECC 200)</div>
+                 <div class="inputs"><label>data</label><input class="dtext" placeholder="Hello" value="Hello"></div>
+                 <div class="row"><button class="run">Generate</button></div>
+                 <div class="apirow"><span class="lbl">API</span><a class="apilink" target="_blank"></a>
+                    <button class="iconbtn copyurl" title="Copy API URL">⧉</button></div>
+                 <div class="reswrap"><div class="result"></div></div>`;
+            const txt = card.querySelector(".dtext");
+            const url = () => location.origin + `/datamatrix?text=${enc(txt.value)}`;
+            const refresh = () => { const u = url(); const a = card.querySelector(".apilink"); a.href = u; a.textContent = u.replace(location.origin, ""); };
+            txt.addEventListener("input", refresh); refresh();
+            card.querySelector(".run").addEventListener("click", () => renderImageResult(card, url()));
+            card.querySelector(".copyurl").addEventListener("click", e => copy(url(), e.currentTarget));
+            return card;
+        }
+
+        // ---------- build page ----------
+        const app = document.getElementById("app");
+        const cats = [...new Set(TOOLS.map(t => t.cat))];
         cats.forEach(cat => {
-            const section = document.createElement("section");
-            section.className = "cat";
-            section.dataset.cat = cat;
-            section.innerHTML = `<h2>${cat}</h2>`;
-            const grid = document.createElement("div");
-            grid.className = "grid";
-
-            TOOLS.filter(t => t.cat === cat).forEach(tool => {
-                const card = document.createElement("div");
-                card.className = "card";
-                card.dataset.search = (tool.name + " " + tool.desc + " " + tool.cat).toLowerCase();
-
-                const inputsHtml = (tool.inputs || []).map(inp =>
-                    `<input id="in-${tool.id}-${inp.k}" placeholder="${inp.ph}" value="${inp.def ?? ""}">`
-                ).join("");
-
-                card.innerHTML =
-                    `<h3>${tool.name}</h3>
-                     <div class="desc">${tool.desc}</div>
-                     <div class="inputs">${inputsHtml}</div>
-                     <div class="row">
-                        <button class="run">Run</button>
-                        <a class="apilink" target="_blank">API ↗</a>
-                     </div>
-                     <div class="result" id="out-${tool.id}"></div>`;
-
-                const btn = card.querySelector("button.run");
-                const link = card.querySelector("a.apilink");
-                btn.addEventListener("click", () => run(tool));
-                const refreshLink = () => { link.href = buildPath(tool); };
-                refreshLink();
-                card.querySelectorAll("input").forEach(i => i.addEventListener("input", refreshLink));
-                card.querySelectorAll(".inputs input").forEach(i =>
-                    i.addEventListener("keydown", e => { if (e.key === "Enter") run(tool); }));
-
-                grid.appendChild(card);
-            });
-
+            const section = el("section", { class: "cat" });
+            section.appendChild(el("h2", null, cat));
+            const grid = el("div", { class: "grid" });
+            TOOLS.filter(t => t.cat === cat).forEach(t => grid.appendChild(makeGenericCard(t)));
             section.appendChild(grid);
             app.appendChild(section);
         });
+        // Codes section (custom image cards)
+        const codeSec = el("section", { class: "cat" });
+        codeSec.appendChild(el("h2", null, "Codes"));
+        const codeGrid = el("div", { class: "grid" });
+        codeGrid.appendChild(makeQRCard());
+        codeGrid.appendChild(makeBarcodeCard());
+        codeGrid.appendChild(makeDataMatrixCard());
+        codeSec.appendChild(codeGrid);
+        app.appendChild(codeSec);
 
-        document.getElementById("count").textContent = TOOLS.length + " tools";
+        document.getElementById("count").textContent = (TOOLS.length + 3) + " tools";
 
-        // Live filter
         document.getElementById("search").addEventListener("input", e => {
             const q = e.target.value.toLowerCase().trim();
             document.querySelectorAll(".cat").forEach(sec => {
-                let visible = 0;
-                sec.querySelectorAll(".card").forEach(card => {
-                    const match = card.dataset.search.includes(q);
-                    card.style.display = match ? "" : "none";
-                    if (match) visible++;
+                let vis = 0;
+                sec.querySelectorAll(".card").forEach(c => {
+                    const m = (c.dataset.search || "").includes(q);
+                    c.style.display = m ? "" : "none"; if (m) vis++;
                 });
-                sec.style.display = visible ? "" : "none";
+                sec.style.display = vis ? "" : "none";
             });
         });
     </script>


### PR DESCRIPTION
## New endpoints
- `GET /barcode?text=&symbology=` — 1D barcode SVG (Code128 default, Code39, EAN-13). xmlns injected so it renders as an `<img>`.
- `GET /datamatrix?text=` — 2D Data Matrix (ECC 200) SVG.

## UI overhaul (`templates/index.html.hbs`)
- **Copy button on every result**, plus a copy button for each tool's **live API URL**.
- **Dropdowns** for enumerable inputs: hash algorithm, text case, barcode symbology.
- **Codes render as images** (not raw SVG text), with a **Download SVG** link.
- **QR type composer**: pick Text / URL / Phone / Email / SMS / WiFi / Geo / Contact(vCard); the right fields appear and the QR payload is built accordingly.
- **API URL** is shown under every tool, **fully URL-encoded** and live-updating so it's copy-paste usable.

## Abuse limits
Per-endpoint caps: QR ≤1000, barcode ≤200, Data Matrix ≤500 chars.

## Deps
`barcoders 2.0` (svg only) and `datamatrix =0.3.2` (pinned to the edition-2021 release so it builds on the server's rustc 1.73; 0.3.3 requires edition 2024).

## Tests
+8 integration tests (barcode symbologies, EAN-13 validation, unknown symbology, size caps, Data Matrix) → **57 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)